### PR TITLE
Multiple tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -15,6 +15,7 @@ import {
   isUuid,
   required
 } from '../../../utils/params'
+import { defaultPageTags } from '../../../utils/tags'
 import { deserializeFitnessActivity } from '../../fitness-activities/justgiving'
 import { fetchTotals, deserializeTotals } from '../../../utils/totals'
 import jsonDate from '../../../utils/jsonDate'
@@ -373,93 +374,20 @@ export const createPageTag = ({
   return request().catch(() => request()) // Retry if request fails
 }
 
-export const createPageTags = page =>
-  Promise.all(
-    [
+export const createPageTags = page => {
+  const request = () =>
+    post(
+      `/v1/tags/${page.slug}/multiple`,
       {
-        id: 'page:totals',
-        label: 'Page Totals'
-      },
-      {
-        id: 'CommsFitness',
-        label: 'CommsFitness',
-        segment: 'AllCommsFitness',
-        measurementDomains: [
-          'any:activities',
-          'any:distance',
-          'any:elapsed_time',
-          'any:elevation_gain',
-          'ride:activities',
-          'ride:distance',
-          'ride:elapsed_time',
-          'ride:elevation_gain',
-          'swim:activities',
-          'swim:distance',
-          'swim:elapsed_time',
-          'swim:elevation_gain',
-          'walk:activities',
-          'walk:distance',
-          'walk:elapsed_time',
-          'walk:elevation_gain'
-        ]
+        tagValues: defaultPageTags(page)
       },
       {
-        id: 'page:charity',
-        label: 'Charity Link',
-        value: `page:charity:${page.charityId}`,
-        segment: `page:charity:${page.charityId}`
-      },
-      {
-        id: `page:charity:${page.charityId}`,
-        label: 'Page Charity Link'
-      },
-      {
-        id: 'page:event',
-        label: 'Event Link',
-        value: `page:event:${page.event}`,
-        segment: `page:event:${page.event}`
-      },
-      {
-        label: 'Page Event Link',
-        id: `page:event:${page.event}`
-      },
-      page.campaign && {
-        id: 'page:campaign',
-        label: 'Campaign Link',
-        value: `page:campaign:${page.campaign}`,
-        segment: `page:campaign:${page.campaign}`
-      },
-      page.campaign && {
-        id: 'page:campaign:charity',
-        label: 'Charity Campaign Link',
-        value: `page:campaign:${page.campaign}:charity:${page.charityId}`,
-        segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
-      },
-      page.campaign && {
-        label: 'Page Campaign Link',
-        id: `page:campaign:${page.campaign}`
-      },
-      page.campaign && {
-        label: 'Page Charity Campaign Link',
-        id: `page:campaign:${page.campaign}:charity:${page.charityId}`
+        timeout: 5000
       }
-    ]
-      .filter(Boolean)
-      .map(({ label, id, value, segment, measurementDomains }) =>
-        createPageTag({
-          slug: page.slug,
-          label,
-          id,
-          value: value || `page:fundraising:${page.uuid}`,
-          aggregation: [
-            {
-              segment: segment || id,
-              measurementDomains: measurementDomains || ['all']
-            }
-          ]
-        })
-      )
-  )
+    )
+
+  return request().catch(() => request()) // Retry if request fails
+}
 
 export const createPage = ({
   charityId = required(),

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -374,12 +374,15 @@ export const createPageTag = ({
   return request().catch(() => request()) // Retry if request fails
 }
 
-export const createPageTags = page => {
+export const createPageTags = ({
+  slug = required(),
+  tagValues = required()
+}) => {
   const request = () =>
     post(
-      `/v1/tags/${page.slug}/multiple`,
+      `/v1/tags/${slug}/multiple`,
       {
-        tagValues: defaultPageTags(page)
+        tagValues
       },
       {
         timeout: 5000
@@ -388,6 +391,9 @@ export const createPageTags = page => {
 
   return request().catch(() => request()) // Retry if request fails
 }
+
+const createDefaultPageTags = page =>
+  createPageTags({ slug: page.slug, tagValues: defaultPageTags(page) })
 
 export const createPage = ({
   charityId = required(),
@@ -478,7 +484,7 @@ export const createPage = ({
     )
       .then(result => fetchPage(result.pageId))
       .then(page => {
-        createPageTags(deserializePage(page)).then(tags => {
+        createDefaultPageTags(deserializePage(page)).then(tags => {
           if (typeof tagsCallback === 'function') {
             tagsCallback(tags, page)
           }

--- a/source/utils/tags/index.js
+++ b/source/utils/tags/index.js
@@ -42,3 +42,140 @@ export const measurementDomains = [
   'walk:elapsed_time',
   'walk:elevation_gain'
 ]
+
+export const defaultPageTags = page => {
+  const tags = [
+    {
+      tagDefinition: {
+        id: 'page:totals',
+        label: 'Page Totals'
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: 'page:totals'
+      }]
+    },
+    {
+      tagDefinition: {
+        id: 'CommsFitness',
+        label: 'CommsFitness'
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: [
+          'any:activities',
+          'any:distance',
+          'any:elapsed_time',
+          'any:elevation_gain',
+          'ride:activities',
+          'ride:distance',
+          'ride:elapsed_time',
+          'ride:elevation_gain',
+          'swim:activities',
+          'swim:distance',
+          'swim:elapsed_time',
+          'swim:elevation_gain',
+          'walk:activities',
+          'walk:distance',
+          'walk:elapsed_time',
+          'walk:elevation_gain'
+        ],
+        segment: 'AllCommsFitness'
+      }]
+    },
+    {
+      tagDefinition: {
+        id: 'page:charity',
+        label: 'Charity Link'
+      },
+      value: `page:charity:${page.charityId}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:charity:${page.charityId}`
+      }]
+    },
+    {
+      tagDefinition: {
+        id: `page:charity:${page.charityId}`,
+        label: 'Page Charity Link'
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:charity:${page.charityId}`
+      }]
+    },
+    {
+      tagDefinition: {
+        id: 'page:event',
+        label: 'Event Link'
+      },
+      value: `page:event:${page.event}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:event:${page.event}`
+      }]
+    },
+    {
+      tagDefinition: {
+        id: `page:event:${page.event}`,
+        label: 'Page Event Link'
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:event:${page.event}`
+      }]
+    }
+  ]
+
+  const campaignTags = [
+    {
+      tagDefinition: {
+        id: 'page:campaign',
+        label: 'Campaign Link'
+      },
+      value: `page:campaign:${page.campaign}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:campaign:${page.campaign}`
+      }]
+    },
+    {
+      tagDefinition: {
+        id: 'page:campaign:charity',
+        label: 'Charity Campaign Link'
+      },
+      value: `page:campaign:${page.campaign}:charity:${page.charityId}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
+      }]
+    },
+    {
+      tagDefinition: {
+        label: 'Page Campaign Link',
+        id: `page:campaign:${page.campaign}`
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:campaign:${page.campaign}`
+      }]
+    },
+    {
+      tagDefinition: {
+        label: 'Page Charity Campaign Link',
+        id: `page:campaign:${page.campaign}:charity:${page.charityId}`
+      },
+      value: `page:fundraising:${page.uuid}`,
+      aggregation: [{
+        measurementDomains: ['all'],
+        segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
+      }]
+    }
+  ]
+
+  return page.campaign ? campaignTags.concat(tags) : tags
+}


### PR DESCRIPTION
Update to use new endpoint to add multiple page tags in one request. This will allow us to cut down on the number of requests and hopefully prevent tag requests from failing. Here is brief video of using this with ARUK:
https://drive.google.com/file/d/1zGA0fEyrFHBhbnoCLYT7YJJGIp4Cin2b/view

As you can see we went from 10 separate tag requests down to 2 (also adding some unique tags specific to ARUK outside of createPage). 

Here is query to show tags registered:
`curl 'https://graphql.staging.justgiving.com/' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Connection: keep-alive' -H 'DNT: 1' -H 'Origin: https://graphql.staging.justgiving.com' --data-binary '{"query":"query {\n  page(\n    type: FUNDRAISING, \n    slug: \"hey-hey-hey-lets-raise-money\"\n  ) {\n    id\n    legacyId\n    title\n    owner {\n      name\n    }\n    tags {\n      tagDefinition {\n        id\n        label\n      }\n      value\n      aggregation {\n        measurementDomains\n        segment\n        timeBox {\n          notBefore\n          notAfter\n        }\n      }\n    }\n    donations(first: 10) {\n      nodes {\n        amount {\n          value\n        }\n        creationDate\n        displayName\n      }\n    }\n  }\n}# Write your query or mutation here\n"}' --compressed`