### PR TITLE
only submit address search if query has value

### DIFF
--- a/source/components/address-search/index.js
+++ b/source/components/address-search/index.js
@@ -29,14 +29,16 @@ class AddressSearch extends Component {
   }
 
   handleQuery (q) {
-    Promise.resolve()
-      .then(() => this.setState({ status: 'fetching' }))
-      .then(() => searchAddress(q, this.state.country))
-      .then(results => this.setState({ results, status: 'fetched' }))
-      .catch(error => {
-        this.setState({ status: 'failed' })
-        return Promise.reject(error)
-      })
+    if (q.length > 0) {
+      Promise.resolve()
+        .then(() => this.setState({ status: 'fetching' }))
+        .then(() => searchAddress(q, this.state.country))
+        .then(results => this.setState({ results, status: 'fetched' }))
+        .catch(error => {
+          this.setState({ status: 'failed' })
+          return Promise.reject(error)
+        })
+    }
   }
 
   handleSelect (selected) {


### PR DESCRIPTION
Getting 404 errors from services API on address search if user deletes out the input. Adding simple check to make sure the query has a value before submitting address search.