### PR TITLE
updates to JG Connect Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.19",
+  "version": "5.2.20",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/jg-connect-form/index.js
+++ b/source/components/jg-connect-form/index.js
@@ -9,6 +9,7 @@ import {
   showPopup
 } from '../../utils/oauth'
 import { parseUrlParams } from '../../utils/params'
+import { getIsMobile } from '../../utils/window'
 import {
   checkAccountAvailability,
   connectToken
@@ -73,6 +74,7 @@ class JGConnectForm extends React.Component {
 
   showOAuth (forceSignUp, email) {
     const { clientId, homeUrl, oauthParams, popup, redirectUri } = this.props
+    const isMobile = getIsMobile()
 
     return Promise.resolve()
       .then(() =>
@@ -94,7 +96,7 @@ class JGConnectForm extends React.Component {
       )
       .then(
         url =>
-          popup
+          popup && !isMobile
             ? showPopup({ url, onClose: this.handleClose })
             : (window.location.href = url)
       )

--- a/source/components/jg-connect-form/index.js
+++ b/source/components/jg-connect-form/index.js
@@ -9,7 +9,7 @@ import {
   showPopup
 } from '../../utils/oauth'
 import { parseUrlParams } from '../../utils/params'
-import { getIsMobile } from '../../utils/window'
+import { getCurrentUrl, getIsMobile } from '../../utils/window'
 import {
   checkAccountAvailability,
   connectToken
@@ -229,7 +229,7 @@ JGConnectForm.propTypes = {
   /**
    * The JG application key
    */
-  clientId: PropTypes.string.isRequired,
+  clientId: PropTypes.string,
 
   /**
    * Props to be passed to the Form component
@@ -269,7 +269,7 @@ JGConnectForm.propTypes = {
   /**
    * The url to redirect to on successful authentication
    */
-  redirectUri: PropTypes.string.isRequired,
+  redirectUri: PropTypes.string,
 
   /**
    * Show Yes/No buttons instead of an email check form
@@ -278,7 +278,10 @@ JGConnectForm.propTypes = {
 }
 
 JGConnectForm.defaultProps = {
-  popup: true
+  clientId: '44f34c65',
+  popup: true,
+  homeUrl: getCurrentUrl(),
+  redirectUri: 'https://oauth.blackbaud-sites.com/'
 }
 
 export default withForm(form)(JGConnectForm)

--- a/source/utils/window/index.js
+++ b/source/utils/window/index.js
@@ -1,0 +1,11 @@
+export const getCurrentUrl = () => {
+  if (typeof window !== 'undefined') {
+    return `${window.location.origin}${window.location.pathname}`
+  }
+}
+
+export const getIsMobile = () => {
+  if (typeof window !== 'undefined') {
+    return navigator.userAgent.match(/Android|iPhone|iPad|iPod/i)
+  }
+}


### PR DESCRIPTION
Adding features to JG Connect Form which we have to repeat in projects. This includes no popup on mobile for Facebook browser bug, and adding default props for client id, redirect uri and home uri, which we use the same values most of the time