### PR TITLE
Fix oauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.21",
+  "version": "5.2.22",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -4,7 +4,7 @@ import URL from 'url-parse'
 import omit from 'lodash/omit'
 import { parseUrlParams } from '../../utils/params'
 import { toPromise } from '../../utils/promise'
-import { servicesAPI } from '../../utils/client'
+import { getBaseURL, servicesAPI } from '../../utils/client'
 import {
   getLocalStorageItem,
   setLocalStorageItem
@@ -145,6 +145,7 @@ class ProviderOauthButton extends Component {
   providerUrl () {
     const {
       clientId,
+      homeUrl,
       provider,
       redirectUri,
       state,
@@ -152,7 +153,23 @@ class ProviderOauthButton extends Component {
       authParams = {}
     } = this.props
 
-    if (provider === 'strava') {
+    if (provider === 'justgiving') {
+      const params = {
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        state: homeUrl && encodeURIComponent(`home=${homeUrl}`),
+        ...authParams
+      }
+
+      const urlParams = Object.keys(params)
+        .map(key => `${key}=${encodeURIComponent(params[key])}`)
+        .join('&')
+
+      const baseURL = getBaseURL().replace('api', 'identity')
+
+      return `${baseURL}/connect/authorize?${urlParams}&scope=openid+profile+email+account+fundraise+offline_access`
+    } else if (provider === 'strava') {
       const baseURL = 'https://www.strava.com/oauth/authorize'
 
       const params = {


### PR DESCRIPTION
Issue reported today where Sitebuilder sites using provider oAuth for JG login no longer working. This was related to updates I made to this component in v5.17.0 where i refactored this to remove EDH. JG was also removed as I assumed we use the jg connect component now, but did not realize this was still used in Sitebuilder. This puts JG back into the oauth component so it works in Sitebuilder again (I reverted Sitebuilder back to earlier version).