### PR TITLE
JG Facebook login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.22",
+  "version": "5.2.23",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import URL from 'url-parse'
 import omit from 'lodash/omit'
-import { parseUrlParams } from '../../utils/params'
+import { base64EncodeParams, parseUrlParams } from '../../utils/params'
 import { toPromise } from '../../utils/promise'
 import { getBaseURL, servicesAPI } from '../../utils/client'
 import {
@@ -98,7 +98,7 @@ class ProviderOauthButton extends Component {
         .catch(() => this.setState({ status: 'empty', success: false }))
     }
 
-    if (provider === 'justgiving') {
+    if (['justgiving', 'facebook'].indexOf(provider) > -1) {
       Promise.resolve()
         .then(() => this.setState({ success: true }))
         .then(() => servicesAPI.post('/v1/justgiving/oauth/connect', data))
@@ -153,12 +153,16 @@ class ProviderOauthButton extends Component {
       authParams = {}
     } = this.props
 
-    if (provider === 'justgiving') {
+    if (['justgiving', 'facebook'].indexOf(provider) > -1) {
       const params = {
         client_id: clientId,
         redirect_uri: redirectUri,
         response_type: 'code',
         state: homeUrl && encodeURIComponent(`home=${homeUrl}`),
+        acr_values:
+          provider === 'facebook'
+            ? `encodedOptions:${base64EncodeParams({ forceFacebook: true })}`
+            : undefined,
         ...authParams
       }
 
@@ -293,7 +297,7 @@ ProviderOauthButton.propTypes = {
   /**
    * The third-party provider to connect with
    */
-  provider: PropTypes.oneOf(['strava', 'fitbit', 'justgiving']),
+  provider: PropTypes.oneOf(['strava', 'facebook', 'fitbit', 'justgiving']),
 
   /**
    * A valid return_to url for the specified OAuthApplication


### PR DESCRIPTION
Adds new parameter to force FB login through OAuth flow. For example:

```jsx
<ProviderOauthButton
  provider='facebook'
  label='Login with Facebook'
  clientId={process.env.JG_OAUTH_API_KEY}
  redirectUri={process.env.JG_REDIRECT_URI}
  onSuccess={console.log}
/>
```