### PR TITLE
use direct JG endpoints for campaign

### DIFF
--- a/source/api/campaigns/__tests__/campaigns-test.js
+++ b/source/api/campaigns/__tests__/campaigns-test.js
@@ -114,10 +114,10 @@ describe('Fetch Campaigns', () => {
         const secondRequest = moxios.requests.at(1)
 
         expect(firstRequest.url).to.equal(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign'
+          'https://api.justgiving.com/campaigns/v2/campaign/my-campaign'
         )
         expect(secondRequest.url).to.equal(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/another-campaign'
+          'https://api.justgiving.com/campaigns/v2/campaign/another-campaign'
         )
         done()
       })
@@ -128,7 +128,7 @@ describe('Fetch Campaigns', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign'
+          'https://api.justgiving.com/campaigns/v2/campaign/my-campaign'
         )
         done()
       })

--- a/source/api/campaigns/justgiving/index.js
+++ b/source/api/campaigns/justgiving/index.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get'
-import { servicesAPI } from '../../../utils/client'
+import client, { servicesAPI } from '../../../utils/client'
 import { baseUrl, imageUrl, parseText } from '../../../utils/justgiving'
 import { required } from '../../../utils/params'
 
@@ -16,9 +16,7 @@ export const fetchCampaigns = ({ ids }) => {
 }
 
 export const fetchCampaign = (id = required()) =>
-  servicesAPI
-    .get(`/v1/justgiving/campaigns/${id}`)
-    .then(response => response.data)
+  client.get(`/campaigns/v2/campaign/${id}`).then(response => response)
 
 export const fetchCampaignGroups = (id = required()) =>
   Promise.reject(new Error('This method is not supported for JustGiving'))

--- a/source/api/campaigns/justgiving/index.js
+++ b/source/api/campaigns/justgiving/index.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get'
-import client, { servicesAPI } from '../../../utils/client'
+import client from '../../../utils/client'
 import { baseUrl, imageUrl, parseText } from '../../../utils/justgiving'
 import { required } from '../../../utils/params'
 

--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -103,7 +103,7 @@ describe('Fetch Donation Totals', () => {
         const secondRequest = moxios.requests.at(1)
 
         expect(firstRequest.url).to.equal(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign'
+          'https://api.justgiving.com/campaigns/v2/campaign/my-campaign'
         )
         expect(secondRequest.url).to.equal(
           'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/pages'

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -11,9 +11,9 @@ import { currencyCode } from '../../../utils/currencies'
 
 const fetchCampaignTotals = id =>
   Promise.all([
-    servicesAPI
-      .get(`/v1/justgiving/campaigns/${id}`)
-      .then(response => response.data.donationSummary),
+    client
+      .get(`/campaigns/v2/campaign/${id}`)
+      .then(response => response.donationSummary),
     servicesAPI
       .get(`/v1/justgiving/campaigns/${id}/pages`)
       .then(response => response.data.meta.totalAmount)


### PR DESCRIPTION
when possible avoid services api. getting lots of errors when we route through services api, see much less when use direct JG endpoints. Since campaigns does not have the CORS issues, no need to use services endpoint here