### PR TITLE
don't make team and page ids required for join team

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -222,9 +222,9 @@ export const createTeam = params => {
 
 export const joinTeam = ({
   authType = 'Bearer',
-  pageId = required(),
+  pageId,
   pageSlug = required(),
-  teamId = required(),
+  teamId,
   teamSlug = required(),
   token = required()
 }) => {


### PR DESCRIPTION
Join team using legacy JG teams endpoint does not need team of page ids (just slugs). If we keep requiring those fields will get bugs in other projects when s9n is updated