### PR TITLE
Dayjs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/fitness-activities/everydayhero/index.js
+++ b/source/api/fitness-activities/everydayhero/index.js
@@ -65,7 +65,7 @@ export const createFitnessActivity = ({
   elevationUnit,
   manual = true,
   pageId,
-  startedAt = dayjs().toISOString(),
+  startedAt = dayjs().format(),
   trainer,
   title,
   uid = uuid(),

--- a/source/api/fitness-activities/justgiving/index.js
+++ b/source/api/fitness-activities/justgiving/index.js
@@ -242,7 +242,7 @@ export const createFitnessActivity = ({
     }
 
     const createdDate = startedAt
-      ? `createdDate: "${dayjs(startedAt).toISOString()}"`
+      ? `createdDate: "${dayjs(startedAt).format()}"`
       : ''
 
     const message = description ? `message: "${description}"` : ''

--- a/source/components/create-fitness-form/index.js
+++ b/source/components/create-fitness-form/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import capitalize from 'lodash/capitalize'
 import get from 'lodash/get'
 import merge from 'lodash/merge'
-import moment from 'moment'
 import dayjs from 'dayjs'
 import withForm from 'constructicon/with-form'
 import * as validators from 'constructicon/lib/validators'
@@ -357,23 +356,23 @@ const form = props => {
         ...(props.includeDate && {
           startedAt: {
             label: 'Date',
-            initial: moment().format('YYYY-MM-DD'),
+            initial: dayjs().format('YYYY-MM-DD'),
             type: 'date',
             validators: [
               val =>
-                val && moment(val).isAfter() && "Date can't be in the future",
+                val && dayjs(val).isAfter() && "Date can't be in the future",
               val =>
                 val &&
                 props.startDate &&
-                moment(val).isBefore(moment(props.startDate)) &&
-                `Date can't be before ${moment(props.startDate).format(
+                dayjs(val).isBefore(dayjs(props.startDate)) &&
+                `Date can't be before ${dayjs(props.startDate).format(
                   'MMMM Do'
                 )}`,
               val =>
                 val &&
                 props.endDate &&
-                moment(val).isAfter(moment(props.endDate)) &&
-                `Date can't be after ${moment(props.startDate).format(
+                dayjs(val).isAfter(dayjs(props.endDate)) &&
+                `Date can't be after ${dayjs(props.startDate).format(
                   'MMMM Do'
                 )}`
             ]

--- a/source/components/create-fitness-form/index.js
+++ b/source/components/create-fitness-form/index.js
@@ -4,6 +4,7 @@ import capitalize from 'lodash/capitalize'
 import get from 'lodash/get'
 import merge from 'lodash/merge'
 import moment from 'moment'
+import dayjs from 'dayjs'
 import withForm from 'constructicon/with-form'
 import * as validators from 'constructicon/lib/validators'
 import { createFitnessActivity } from '../../api/fitness-activities'
@@ -38,8 +39,8 @@ class CreateFitnessForm extends Component {
         pageSlug,
         token,
         userId,
-        startedAt: moment(data.startedAt).isSame(moment(), 'day')
-          ? moment().toISOString()
+        startedAt: dayjs(data.startedAt).isSame(dayjs(), 'day')
+          ? dayjs().format()
           : data.startedAt,
         type: isJustGiving()
           ? data.type

--- a/source/utils/jsonDate/index.js
+++ b/source/utils/jsonDate/index.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 export default date => {
   const isValid = dayjs(date).isValid()
   if (isValid) {
-    return dayjs(date).toISOString()
+    return dayjs(date).format()
   } else if (date.indexOf('/Date(') !== -1) {
     // Day.js does not now how to deal with JG formatted UNIX time, so strip out extra parts of string and just serve up digits of UNIX timestamp to convert to ISO
     const prepareStr = Number(
@@ -12,7 +12,7 @@ export default date => {
         .replace(')/', '')
         .split('+')[0]
     )
-    const formatUnix = dayjs(prepareStr).toISOString()
+    const formatUnix = dayjs(prepareStr).format()
     return formatUnix
   }
 }

--- a/source/utils/jsonDate/index.js
+++ b/source/utils/jsonDate/index.js
@@ -1,3 +1,18 @@
 import dayjs from 'dayjs'
 
-export default date => dayjs.isDayjs(dayjs(date)) && dayjs(date).toISOString()
+export default date => {
+  const isValid = dayjs(date).isValid()
+  if (isValid) {
+    return dayjs(date).toISOString()
+  } else if (date.indexOf('/Date(') !== -1) {
+    // Day.js does not now how to deal with JG formatted UNIX time, so strip out extra parts of string and just serve up digits of UNIX timestamp to convert to ISO
+    const prepareStr = Number(
+      date
+        .replace('/Date(', '')
+        .replace(')/', '')
+        .split('+')[0]
+    )
+    const formatUnix = dayjs(prepareStr).toISOString()
+    return formatUnix
+  }
+}


### PR DESCRIPTION
Few updates dealing with dayjs:
1) Dayjs is not able to handle how JG serves up UNIX dates (ie '\Date(UNIX timestamp)'). Also, when passing something it can't parse, is still evaluates to true when testing if is a day obj (returns string Is Invalid Date), you have to use isValid to test.

2) To parse ISO local you actually just have to use format(). Using toISOStrong with day obj was setting in UTC time in my testing. Just using dayjs().format() by default gives you ISO in local