### PR TITLE
Signup error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^2.9.10",
+    "constructicon": "^3.0.3",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^5.6.0",
@@ -72,7 +72,7 @@
     "url-parse": "^1.4.3"
   },
   "peerDependencies": {
-    "constructicon": "^1.8.0",
+    "constructicon": "^2.0.0 || ^3.0.0",
     "numbro": "^1.0.0 || ^2.0.0",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/fitness-progress-bar/index.js
+++ b/source/components/fitness-progress-bar/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import numbro from 'numbro'
 import { fetchFitnessTotals } from '../../api/fitness-totals'
 
@@ -44,9 +44,9 @@ class FitnessProgressBar extends Component {
   }
 
   calculateDaysRemaining (eventDate) {
-    const today = moment()
-    const eventMoment = moment(eventDate)
-    const daysDiff = Math.ceil(eventMoment.diff(today, 'days', true)) // we want to round up
+    const today = dayjs()
+    const eventDateObj = dayjs(eventDate)
+    const daysDiff = Math.ceil(eventDateObj.diff(today, 'days', true)) // we want to round up
     return Math.max(0, daysDiff)
   }
 

--- a/source/components/login-form/__tests__/login-form-test.js
+++ b/source/components/login-form/__tests__/login-form-test.js
@@ -11,7 +11,7 @@ describe('Components | LoginForm', () => {
         <LoginForm clientId='1234abcd' onSuccess={res => console.log(res)} />
       )
       const inputs = wrapper.find('input')
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(inputs.length).to.eql(2)
       expect(button.length).to.eql(1)
@@ -41,7 +41,7 @@ describe('Components | LoginForm', () => {
         />
       )
       const inputs = wrapper.find('input')
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(inputs.length).to.eql(2)
       expect(button.length).to.eql(1)

--- a/source/components/progress-bar/index.js
+++ b/source/components/progress-bar/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import numbro from 'numbro'
 import {
   fetchDonationTotals,
@@ -61,9 +61,9 @@ class ProgressBar extends Component {
   }
 
   calculateDaysRemaining (eventDate) {
-    const today = moment()
-    const eventMoment = moment(eventDate)
-    const daysDiff = Math.ceil(eventMoment.diff(today, 'days', true)) // we want to round up
+    const today = dayjs()
+    const eventDateObj = dayjs(eventDate)
+    const daysDiff = Math.ceil(eventDateObj.diff(today, 'days', true)) // we want to round up
     return Math.max(0, daysDiff)
   }
 

--- a/source/components/signup-form/PasswordValidations/index.js
+++ b/source/components/signup-form/PasswordValidations/index.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { regularExpressions } from 'constructicon/lib/validators'
+
+import ButtonGroup from 'constructicon/button-group'
+import Icon from 'constructicon/icon'
+import Section from 'constructicon/section'
+
+const containsSubstring = (valueA, valueB) => {
+  if (!valueA || !valueB) return false
+
+  return (
+    String(valueA)
+      .toLowerCase()
+      .indexOf(valueB.toLowerCase()) > -1
+  )
+}
+
+const PasswordValidations = ({ form }) => {
+  const passwordValidations = [
+    {
+      label: 'Must be at least 12 characters',
+      passes: form.values.password.length > 11
+    },
+    {
+      label:
+        'Must include at least one number, letter and special character (#,$,%,&,@ etc.)',
+      passes: regularExpressions.passwordComplexity.test(form.values.password)
+    },
+    {
+      label: 'Must not include your name or email address',
+      passes:
+        !containsSubstring(form.values.password, form.values.email) &&
+        !containsSubstring(form.values.password, form.values.firstName) &&
+        !containsSubstring(form.values.password, form.values.lastName)
+    }
+  ]
+
+  return (
+    <Section spacing={0} margin={{ t: -0.5, b: 0.75 }}>
+      {passwordValidations.map((validation, index) => (
+        <Section
+          foreground={
+            validation.passes && form.fields.password.touched
+              ? 'success'
+              : 'grey'
+          }
+          key={index}
+          spacing={{ y: 0.333 }}
+          textAlign='left'
+          size={-0.5}
+          tag='div'
+        >
+          <ButtonGroup align='left' spacing={0}>
+            <Icon
+              name={validation.passes ? 'check' : 'close'}
+              color={validation.passes ? 'success' : 'danger'}
+            />
+            <Section
+              spacing={{ l: 0.5 }}
+              styles={{ maxWidth: 'calc(100% - 3em)', verticalAlign: 'middle' }}
+            >
+              {validation.label}
+            </Section>
+          </ButtonGroup>
+        </Section>
+      ))}
+    </Section>
+  )
+}
+
+export default PasswordValidations

--- a/source/components/signup-form/__tests__/signup-form-test.js
+++ b/source/components/signup-form/__tests__/signup-form-test.js
@@ -16,7 +16,7 @@ describe('Components | SignupForm', () => {
       )
       const inputs = wrapper.find('input')
       const select = wrapper.find('select')
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(inputs.length).to.eql(5)
       expect(select.length).to.eql(0)
@@ -43,7 +43,7 @@ describe('Components | SignupForm', () => {
           onSuccess={res => console.log(res)}
         />
       )
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(button.length).to.eql(1)
       expect(button.text()).to.eql('Sign Up to EDH')
@@ -67,7 +67,7 @@ describe('Components | SignupForm', () => {
     it('renders a simple sign up form with custom submit prop', () => {
       const wrapper = mount(<SignupForm onSuccess={res => console.log(res)} />)
       const inputs = wrapper.find('input')
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(inputs.length).to.eql(4)
       expect(button.length).to.eql(1)
@@ -81,7 +81,7 @@ describe('Components | SignupForm', () => {
           onSuccess={res => console.log(res)}
         />
       )
-      const button = wrapper.find('button')
+      const button = wrapper.find('button[type="submit"]')
 
       expect(button.length).to.eql(1)
       expect(button.text()).to.eql('Sign Up to JustGiving')

--- a/source/components/signup-form/index.js
+++ b/source/components/signup-form/index.js
@@ -457,7 +457,20 @@ const form = props => {
         autoComplete: 'off',
         validators: [
           validators.required('Password is a required field'),
-          validators.greaterThan(11, 'Must be at least 12 characters')
+          validators.greaterThan(11, 'Must be at least 12 characters'),
+          validators.passwordComplexity(),
+          validators.doesNotContainField(
+            'firstName',
+            'Your password must not include your first name'
+          ),
+          validators.doesNotContainField(
+            'lastName',
+            'Your password must not include your last name'
+          ),
+          validators.doesNotContainField(
+            'email',
+            'Your password must not include your email address'
+          )
         ]
       }
     },

--- a/source/components/signup-form/index.js
+++ b/source/components/signup-form/index.js
@@ -17,6 +17,7 @@ import Icon from 'constructicon/icon'
 import InputField from 'constructicon/input-field'
 import InputSelect from 'constructicon/input-select'
 import Modal from 'constructicon/modal'
+import PasswordValidations from './PasswordValidations'
 import RichText from 'constructicon/rich-text'
 import Section from 'constructicon/section'
 
@@ -212,6 +213,7 @@ class SignupForm extends Component {
       includeTerms,
       inputField,
       legend,
+      showPasswordValidations,
       submit
     } = this.props
 
@@ -243,7 +245,14 @@ class SignupForm extends Component {
         </Grid>
 
         <InputField {...form.fields.email} {...inputField} />
-        <InputField {...form.fields.password} {...inputField} />
+        <InputField
+          {...form.fields.password}
+          validations={
+            showPasswordValidations ? [] : form.fields.password.validations
+          }
+          {...inputField}
+        />
+        {showPasswordValidations && <PasswordValidations form={form} />}
 
         {!isJustGiving() ? (
           country ? (
@@ -397,6 +406,11 @@ SignupForm.propTypes = {
   resetPasswordTarget: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
 
   /**
+   * Include JG password validations helper
+   */
+  showPasswordValidations: PropTypes.bool,
+
+  /**
    * The label for the form submit button
    */
   submit: PropTypes.string
@@ -406,6 +420,7 @@ SignupForm.defaultProps = {
   authType: 'Bearer',
   disableInvalidForm: false,
   fields: {},
+  showPasswordValidations: true,
   submit: 'Sign Up',
   legend: {
     size: 0.5,

--- a/test/common.js
+++ b/test/common.js
@@ -22,4 +22,4 @@ global.mount = enzyme.mount
 
 global.utils = require('./utils')
 
-require('./testdom')('<html><body></body></html>')
+require('./testdom')('<html><body><div id="mount"><div></body></html>')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,15 +1869,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.4.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 char-spinner@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/char-spinner/-/char-spinner-1.0.1.tgz#e6ea67bd247e107112983b7ab0479ed362800081"
@@ -2176,6 +2167,11 @@ commander@^2.14.1:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
 
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
@@ -2271,17 +2267,17 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^2.9.10:
-  version "2.9.10"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-2.9.10.tgz#3c11c0e2374bc628957f470bafee70cddf8cb768"
-  integrity sha512-QYAdS3EJ+l1WBQ0a1ClfTPK6UQRZ/waEojc8KJRXijM1lQAyh1qdUJcKsGxLH6ehTd06Pp84YBBQtG7zDRg7iw==
+constructicon@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-3.0.3.tgz#2f31be1f21db8ca1f55cdbb3880b4a789992b70e"
+  integrity sha512-qYcOnQtiCsR3qri5rZHkfkFHzME5X05yl06kC1YXum1MOrN8WXVwG5YelI2RIb98ouNm4d1hH0BZ+ZGJ2MUwSQ==
   dependencies:
     axios "^0.19.2"
+    dayjs "^1.10.5"
     emotion "^9.2.7"
     emotion-server "^9.2.7"
     filestack-js "^3.12.4"
     lodash "^4.17.15"
-    moment "^2.26.0"
     prop-types "^15.7.2"
     query-string "5.1.1"
     react-avatar-editor "^11.0.9"
@@ -2292,7 +2288,7 @@ constructicon@^2.9.10:
     react-slick "^0.26.1"
     react-slider "^1.0.7"
     react-ticker "^1.2.2"
-    sanitize-html "^1.24.0"
+    xss "^1.0.9"
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -2523,6 +2519,11 @@ css-what@2.1:
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
 cssnano@^3.10.0:
   version "3.10.0"
@@ -2900,14 +2901,6 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-serializer@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
 dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -2923,11 +2916,6 @@ domain-browser@^1.1.1:
 domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
 domelementtype@~1.1.1:
   version "1.1.3"
@@ -2945,13 +2933,6 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domhandler@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
-  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
-  dependencies:
-    domelementtype "^2.0.1"
-
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -2964,15 +2945,6 @@ domutils@1.5.1, domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-domutils@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
-  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
-  dependencies:
-    dom-serializer "^0.2.1"
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -3093,11 +3065,6 @@ enquire.js@^2.1.6:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
-entities@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.2.tgz#ac74db0bba8d33808bbf36809c3a5c3683531436"
-  integrity sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==
 
 enzyme-adapter-react-16@^1.15.2:
   version "1.15.2"
@@ -4804,16 +4771,6 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
-htmlparser2@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
-  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    domutils "^2.0.0"
-    entities "^2.0.0"
-
 htmlparser2@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
@@ -6069,11 +6026,6 @@ lodash.escape@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
   integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
 
-lodash.escaperegexp@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
-  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -6099,7 +6051,7 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-lodash.isplainobject@^4.0.4, lodash.isplainobject@^4.0.6:
+lodash.isplainobject@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
@@ -6131,11 +6083,6 @@ lodash.memoize@^4.1.0, lodash.memoize@^4.1.2:
 lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.pad@^4.1.0:
   version "4.5.1"
@@ -6625,11 +6572,6 @@ mocha@^3.2.0:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
-
-moment@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -7963,15 +7905,6 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
-postcss@^7.0.27:
-  version "7.0.30"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.30.tgz#cc9378beffe46a02cbc4506a0477d05fcea9a8e2"
-  integrity sha512-nu/0m+NtIzoubO+xdAlwZl/u5S5vi/y6BCsoL8D+8IxsD3XvBS8X4YEADNIVXKVuQvduiucnRv+vPIqj56EGMQ==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -9201,22 +9134,6 @@ samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
 
-sanitize-html@^1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.24.0.tgz#9cd42f236512bfcf6259424e958551148c165a7f"
-  integrity sha512-TAIFx39V/y06jDd4YUz7ntCdMUXN5Z28pSG7sTP2BCLXwHA9+ermacDpQs35Evo4p6YSgmaPdSbGiX4Fgptuuw==
-  dependencies:
-    chalk "^2.4.1"
-    htmlparser2 "^4.1.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.escaperegexp "^4.1.2"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.mergewith "^4.6.2"
-    postcss "^7.0.27"
-    srcset "^2.0.1"
-    xtend "^4.0.1"
-
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
@@ -9622,11 +9539,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-srcset@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/srcset/-/srcset-2.0.1.tgz#8f842d357487eb797f413d9c309de7a5149df5ac"
-  integrity sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==
-
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
@@ -9910,13 +9822,6 @@ supports-color@^3.2.3:
 supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
@@ -10824,6 +10729,14 @@ xml-char-classes@^1.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xss@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.9.tgz#3ffd565571ff60d2e40db7f3b80b4677bec770d2"
+  integrity sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- Add popup for existing email error on signup form
- Add extra JG password validations to signup form
- Add password requirements guide

![error-popup](https://user-images.githubusercontent.com/729085/123210089-db413000-d504-11eb-85e0-723600487900.png)

![pw-validation](https://user-images.githubusercontent.com/729085/123210074-d67c7c00-d504-11eb-9d00-1b3940a68c47.gif)

**Note: this change relies on the current latest version of c11n, and as there was a recent major version bump I figure it's time to update the c11n peer dependency to be at least v2 or 3 (obviously not full support for v2, but maybe you just want a newer s9n for a util method?).**