### PR TITLE
Use tag leaderboards for elevation/duration/activities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.0.8",
+  "version": "6.1.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -34,7 +34,7 @@ export const fetchFitnessLeaderboard = ({
   type,
   useLegacy = true
 }) => {
-  if (tagId || tagValue) {
+  if (tagId || tagValue || sortBy !== 'distance') {
     return fetchLeaderboard({
       activityType,
       id: getUID(campaign),
@@ -95,6 +95,13 @@ export const deserializeFitnessLeaderboard = (item, index) => {
     slug,
     status: item.status,
     subtitle: get(item, 'owner.name'),
+    totals: get(item, 'amounts', []).reduce(
+      (totals, amount) => ({
+        ...totals,
+        [amount.unit]: amount.value
+      }),
+      {}
+    ),
     url:
       item.url ||
       [baseUrl(), item.type === 'team' ? 'team' : 'fundraising', slug].join('/')

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -2,9 +2,11 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
 import {
+  formatActivities,
   formatDistance,
   formatDuration,
-  formatElevation
+  formatElevation,
+  formatMeasurementDomain
 } from '../../utils/fitness'
 
 import Filter from 'constructicon/filter'
@@ -103,7 +105,7 @@ class FitnessLeaderboard extends Component {
       limit: limit + 10,
       page,
       groupID,
-      sortBy,
+      sortBy: formatMeasurementDomain(sortBy),
       q,
       tagId,
       tagValue
@@ -218,16 +220,15 @@ class FitnessLeaderboard extends Component {
 
   getMetric (leader) {
     const { miles, multiplier, offset, sortBy, units } = this.props
+    const { totals = {} } = leader
 
     switch (sortBy) {
-      case 'calories':
-        return `${numbro((offset + leader.calories) * multiplier).format(
-          '0,0'
-        )} cals`
+      case 'activities':
+        return formatActivities((offset + totals.count) * multiplier)
       case 'duration':
-        return formatDuration((offset + leader.duration) * multiplier)
+        return formatDuration((offset + totals.seconds) * multiplier)
       case 'elevation':
-        return formatElevation((offset + leader.elevation) * multiplier, miles)
+        return formatElevation((offset + totals.meters) * multiplier, miles)
       default:
         const distance = (offset + leader.distance) * multiplier
         return units
@@ -238,17 +239,16 @@ class FitnessLeaderboard extends Component {
 
   getMetricLabel (leader) {
     const { miles, multiplier, offset, sortBy, units } = this.props
+    const { totals = {} } = leader
 
     switch (sortBy) {
-      case 'calories':
-        return `${numbro((offset + leader.calories) * multiplier).format(
-          '0,0'
-        )} calories`
+      case 'activities':
+        return formatActivities((offset + totals.count) * multiplier)
       case 'duration':
-        return formatDuration((offset + leader.duration) * multiplier, 'full')
+        return formatDuration((offset + totals.seconds) * multiplier, 'full')
       case 'elevation':
         return formatElevation(
-          (offset + leader.elevation) * multiplier,
+          (offset + totals.meters) * multiplier,
           miles,
           'full'
         )
@@ -355,7 +355,7 @@ FitnessLeaderboard.propTypes = {
   /**
    * The type of measurement to sort by
    */
-  sortBy: PropTypes.oneOf(['distance', 'duration', 'calories', 'elevation']),
+  sortBy: PropTypes.oneOf(['distance', 'duration', 'elevation']),
 
   /**
    * Props to be passed to the Constructicon Leaderboard component

--- a/source/utils/fitness/index.js
+++ b/source/utils/fitness/index.js
@@ -14,6 +14,17 @@ const labels = {
   meters: { abbreviation: 'm', full: 'meters' }
 }
 
+export const formatMeasurementDomain = sortBy => {
+  switch (sortBy) {
+    case 'duration':
+      return 'elapsed_time'
+    case 'elevation':
+      return 'elevation_gain'
+    default:
+      return sortBy
+  }
+}
+
 export const formatDistance = (distance, miles, label = 'abbreviation') => {
   if (miles) {
     return (
@@ -53,6 +64,10 @@ export const formatElevation = (elevation, miles, label = 'abbreviation') => {
   } else {
     return numbro(elevation).format('0,0') + ` ${labels.meters[label]}`
   }
+}
+
+export const formatActivities = activities => {
+  return numbro(activities).format('0,0')
 }
 
 export const getDistanceTotal = (page = {}) => {


### PR DESCRIPTION
Only distance leaderboards are currently supported in the s9n FitnessLeaderboard component, but we do have the pieces required to return other leaderboards thanks to Rowan's work in SiteBuilder to create leaderboard definitions.

* Format the measurement domain e.g. "elevation" = "elevation_gain"
* Still use the current method if sortBy = "distance"
* For non-distance leaderboards, use the GraphQL tags based leaderboards
* Add a totals property to the deserialize method that deserializes whatever units are returned e.g. meters, seconds, count
* Update the leaderboard to render the correct total based on the "sortBy" e.g. activities uses totals.count

![image](https://user-images.githubusercontent.com/1445686/124079457-81a0ae80-da8c-11eb-8cb9-8c31bc0e895f.png)
