### PR TITLE
Exclude teams by id/slug from JoinTeamForm list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/join-team-form/index.js
+++ b/source/components/join-team-form/index.js
@@ -26,7 +26,7 @@ class JoinTeamForm extends React.Component {
   }
 
   componentDidMount () {
-    const { campaign } = this.props
+    const { campaign, excludeTeamIds } = this.props
 
     const params = {
       campaign,
@@ -43,6 +43,18 @@ class JoinTeamForm extends React.Component {
           label: team.name
         }))
       )
+      .then(teams => {
+        if (!excludeTeamIds) return teams
+
+        return teams.filter(team =>
+          ['id', 'slug'].reduce((current, key) => {
+            if (!team[key]) return current
+            return current
+              ? excludeTeamIds.indexOf(team[key].toString()) < 0
+              : false
+          }, true)
+        )
+      })
       .then(teams => this.setState({ status: 'fetched', teams }))
   }
 
@@ -118,6 +130,11 @@ JoinTeamForm.propTypes = {
    * The campaignId you want to join teams in
    */
   campaign: PropTypes.string,
+
+  /**
+   * Team ids you want to exclude from the list
+   */
+  excludeTeamIds: PropTypes.string,
 
   /**
    * Props to be passed to the Form component


### PR DESCRIPTION
There's no scalable way I could find to fetch a large list of JG teams and also their membership policy at the same time. This allows us to manually exclude invite-only teams from the available list in `JoinTeamForm`