### PR TITLE
fetch event and eventInfo hook

### DIFF
--- a/source/api/events/__tests__/events-test.js
+++ b/source/api/events/__tests__/events-test.js
@@ -1,0 +1,43 @@
+import moxios from 'moxios'
+import { instance, updateClient } from '../../../utils/client'
+import { fetchEvent } from '..'
+
+describe('Fetch Event', () => {
+  describe('fetch justgiving event', () => {
+    beforeEach(() => {
+      updateClient({
+        baseURL: 'https://api.justgiving.com',
+        headers: { 'x-api-key': 'abcd1234' }
+      })
+      return moxios.install(instance)
+    })
+
+    afterEach(() => moxios.uninstall(instance))
+
+    it('throws if event is requested', () => {
+      const test = () => fetchEvent({ id: '12345' })
+      expect(test).to.throw
+    })
+
+    it('fetches a single event', done => {
+      fetchEvent({ id: '12345' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.equal(
+          'https://api.justgiving.com/v1/event/12345'
+        )
+        done()
+      })
+    })
+
+    it('throws with incorrect params', () => {
+      const test = () => fetchEvent({ charity: 'charity' })
+      expect(test).to.throw
+    })
+
+    it('throws if a event is requested, but no id is supplied', () => {
+      const test = () => fetchEvent()
+      expect(test).to.throw
+    })
+  })
+})

--- a/source/api/events/__tests__/events-test.js
+++ b/source/api/events/__tests__/events-test.js
@@ -12,7 +12,10 @@ describe('Fetch Event', () => {
       return moxios.install(instance)
     })
 
-    afterEach(() => moxios.uninstall(instance))
+    afterEach(() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
+    })
 
     it('throws if event is requested', () => {
       const test = () => fetchEvent({ id: '12345' })

--- a/source/api/events/index.js
+++ b/source/api/events/index.js
@@ -1,21 +1,13 @@
-import dayjs from 'dayjs'
 import { get } from '../../utils/client'
 import { required } from '../../utils/params'
-
-const formatUnixString = time =>
-  Number(
-    time
-      .replace('/Date(', '')
-      .replace('+0000', '')
-      .replace(')/', '')
-  )
+import jsonDate from '../../utils/jsonDate'
 
 export const deserializeEvent = event => {
   return {
     ...event,
-    completionDate: dayjs(formatUnixString(event.completionDate)).format(),
-    expiryDate: dayjs(formatUnixString(event.expiryDate)).format(),
-    startDate: dayjs(formatUnixString(event.startDate)).format()
+    completionDate: jsonDate(event.completionDate),
+    expiryDate: jsonDate(event.expiryDate),
+    startDate: jsonDate(event.startDate)
   }
 }
 

--- a/source/api/events/index.js
+++ b/source/api/events/index.js
@@ -1,0 +1,22 @@
+import dayjs from 'dayjs'
+import { get } from '../../utils/client'
+import { required } from '../../utils/params'
+
+const formatUnixString = time =>
+  Number(
+    time
+      .replace('/Date(', '')
+      .replace('+0000', '')
+      .replace(')/', '')
+  )
+
+export const deserializeEvent = event => {
+  return {
+    ...event,
+    completionDate: dayjs(formatUnixString(event.completionDate)).format(),
+    expiryDate: dayjs(formatUnixString(event.expiryDate)).format(),
+    startDate: dayjs(formatUnixString(event.startDate)).format()
+  }
+}
+
+export const fetchEvent = ({ id = required() }) => get(`v1/event/${id}`)

--- a/source/hooks/use-event-info/index.js
+++ b/source/hooks/use-event-info/index.js
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback } from 'react'
+import { deserializeEvent, fetchEvent } from '../../api/events'
+
+export const useEventInfo = id => {
+  if (useState === undefined) {
+    console.error(
+      'Current version of React does not support Hooks. Upgrade React to 16.8 to use supporticon/hooks'
+    )
+    return []
+  }
+
+  const [status, setStatus] = useState(null)
+  const [event, setEvent] = useState(null)
+  const [error, setError] = useState(null)
+  const reload = useCallback(async () => {
+    setStatus('fetching')
+    try {
+      const response = await fetchEvent(id)
+      if (response && response.id) {
+        setStatus('fetched')
+        setEvent(deserializeEvent(response))
+      } else {
+        setStatus('failed')
+        setError(response.message)
+      }
+    } catch (error) {
+      setStatus('failed')
+      setError(error)
+    }
+  }, [])
+
+  useEffect(
+    () => {
+      reload()
+    },
+    [reload]
+  )
+
+  return { event, error, status, reload }
+}


### PR DESCRIPTION
Adding fetchEvent method and eventInfo hook. Based on DUK Event Hub:
https://github.com/blackbaud-services/duk-events-hub/blob/main/lib/justgiving/index.js#L240
https://github.com/blackbaud-services/duk-events-hub/blob/main/components/hooks/useEvent/index.js

We are using these to fetch event info to show logged in user when their event expires:
https://drive.google.com/file/d/1FhKTVnEEeWGunlQd1qTVZ0zG9Fb46XKl/view

Oner thing to note is that the JG API for event returns dates in strange format (a string with unix timestamp surrounded by '/Date(${unix timestamp)/'. Stripping out this to just include unix digit so we can actually format it using dayjs.
