### PR TITLE
move post form validation to promise chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.2.7",
+  "version": "6.2.8",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-post-form/form.js
+++ b/source/components/create-post-form/form.js
@@ -1,19 +1,8 @@
-import * as validators from 'constructicon/lib/validators'
-
-export default ({ post }) => ({
+export default () => ({
   fields: {
     message: {
       label: 'Post an update',
-      type: 'contenteditable',
-      validators: [
-        (val, { image, video }) => {
-          if (!image && !video) {
-            return validators.required(
-              'Please include a message or an image or video.'
-            )(val)
-          }
-        }
-      ]
+      type: 'contenteditable'
     },
     image: {
       label: 'Attach an image'

--- a/source/components/create-post-form/index.js
+++ b/source/components/create-post-form/index.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import withForm from 'constructicon/with-form'
+import isEmpty from 'lodash/isEmpty'
 import get from 'lodash/get'
+import values from 'lodash/values'
 import form from './form'
 import { createPost } from '../../api/posts'
 import { uploadImage } from '../../api/images'
@@ -37,6 +39,13 @@ class CreatePostForm extends React.Component {
 
     form.submit().then(data =>
       Promise.resolve()
+        .then(
+          () =>
+            values(data).every(isEmpty) &&
+            Promise.reject({
+              message: 'Please include a message or an image or video.'
+            })
+        )
         .then(() => this.setState({ status: 'fetching' }))
         .then(() => data.image && uploadImage(data.image))
         .then(image =>


### PR DESCRIPTION
When tabbing through the post form the error validation message shows because we are testing validation using c11n required validator and triggering when image, video and message are blank. 

We discussed changing input field validations altogether, and this does not deal with that. Rather opted to resolve this specific use case since this is actually due to validation on based on 3 fields being set in form validation for a single input, so makes sense to move validation away from the single input and move this check into the promise chain (providing error message there since really this is not related to one field, but rather the whole form). 

Quick video showing error message being triggered and moved away from inline to form error. Also, remove error and submit form which fails because it calls EDH still.
https://drive.google.com/file/d/1kBJ8eOM0z-PxJX2eO1caTzAR4vD0e_PB/view