### PR TITLE
Add timebox param to be included with page tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "6.2.8",
+  "version": "6.2.9",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -407,8 +407,8 @@ export const createPageTags = ({
   return request().catch(() => request()) // Retry if request fails
 }
 
-const createDefaultPageTags = page =>
-  createPageTags({ slug: page.slug, tagValues: defaultPageTags(page) })
+const createDefaultPageTags = (page, timeBox) =>
+  createPageTags({ slug: page.slug, tagValues: defaultPageTags(page, timeBox) })
 
 export const createPage = ({
   charityId = required(),
@@ -444,6 +444,7 @@ export const createPage = ({
   target,
   teamId,
   theme,
+  timeBox,
   videos
 }) => {
   const pageTitle = title.replace(/’/g, "'")
@@ -499,7 +500,7 @@ export const createPage = ({
     )
       .then(result => fetchPage(result.pageId))
       .then(page => {
-        createDefaultPageTags(deserializePage(page)).then(tags => {
+        createDefaultPageTags(deserializePage(page), timeBox).then(tags => {
           if (typeof tagsCallback === 'function') {
             tagsCallback(tags, page)
           }

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -58,6 +58,7 @@ class CreatePageForm extends Component {
       form,
       onSubmitError,
       onSuccess,
+      timeBox,
       token
     } = this.props
 
@@ -91,6 +92,7 @@ class CreatePageForm extends Component {
             charityOptIn: true,
             eventId,
             token,
+            timeBox,
             currency: currencyCode(country),
             groupValues: mapKeys(groupFields, (value, key) =>
               key.replace('group_values_', '')
@@ -388,6 +390,11 @@ CreatePageForm.propTypes = {
    * The label for the form submit button
    */
   submit: PropTypes.string,
+
+  /**
+   * Timebox to be applied to page tags
+   */
+  timeBox: PropTypes.object,
 
   /**
    * The logged in users' auth token

--- a/source/utils/tags/index.js
+++ b/source/utils/tags/index.js
@@ -43,7 +43,7 @@ export const measurementDomains = [
   'walk:elevation_gain'
 ]
 
-export const defaultPageTags = page => {
+export const defaultPageTags = (page, timeBox) => {
   const tags = [
     {
       tagDefinition: {
@@ -54,7 +54,8 @@ export const defaultPageTags = page => {
       aggregation: [
         {
           measurementDomains: ['all'],
-          segment: 'page:totals'
+          segment: 'page:totals',
+          timeBox
         }
       ]
     },
@@ -66,26 +67,32 @@ export const defaultPageTags = page => {
       value: `page:fundraising:${page.uuid}`,
       aggregation: [
         {
-          measurementDomains: [
-            'any:activities',
-            'any:distance',
-            'any:elapsed_time',
-            'any:elevation_gain',
-            'ride:activities',
-            'ride:distance',
-            'ride:elapsed_time',
-            'ride:elevation_gain',
-            'swim:activities',
-            'swim:distance',
-            'swim:elapsed_time',
-            'swim:elevation_gain',
-            'walk:activities',
-            'walk:distance',
-            'walk:elapsed_time',
-            'walk:elevation_gain'
-          ],
+          measurementDomains,
           segment: 'AllCommsFitness'
-        }
+        },
+        ...(timeBox
+          ? [
+            {
+              measurementDomains,
+              segment: 'BeforeEventCommsFitness',
+              timeBox: {
+                notAfter: timeBox.notBefore
+              }
+            },
+            {
+              measurementDomains,
+              segment: 'DuringEventCommsFitness',
+              timeBox
+            },
+            {
+              measurementDomains,
+              segment: 'AfterEventCommsFitness',
+              timeBox: {
+                notBefore: timeBox.notAfter
+              }
+            }
+          ]
+          : [])
       ]
     },
     {
@@ -110,7 +117,8 @@ export const defaultPageTags = page => {
       aggregation: [
         {
           measurementDomains: ['all'],
-          segment: `page:charity:${page.charityId}`
+          segment: `page:charity:${page.charityId}`,
+          timeBox
         }
       ]
     },
@@ -136,7 +144,8 @@ export const defaultPageTags = page => {
       aggregation: [
         {
           measurementDomains: ['all'],
-          segment: `page:event:${page.event}`
+          segment: `page:event:${page.event}`,
+          timeBox
         }
       ]
     },
@@ -217,7 +226,8 @@ export const defaultPageTags = page => {
       aggregation: [
         {
           measurementDomains: ['all'],
-          segment: `page:campaign:${page.campaign}`
+          segment: `page:campaign:${page.campaign}`,
+          timeBox
         }
       ]
     },
@@ -230,7 +240,8 @@ export const defaultPageTags = page => {
       aggregation: [
         {
           measurementDomains: ['all'],
-          segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
+          segment: `page:campaign:${page.campaign}:charity:${page.charityId}`,
+          timeBox
         }
       ]
     }


### PR DESCRIPTION
Adds support to pass on `timeBox` param when creating page tags.

Also adds handling to enable comms before, during and after event dates.