### PR TITLE
remove deprecated method to fetch fitness activities

### DIFF
--- a/source/api/fitness-activities/__tests__/fetch-activities-test.js
+++ b/source/api/fitness-activities/__tests__/fetch-activities-test.js
@@ -1,13 +1,13 @@
-import { instance } from '../../../utils/client'
+import { servicesAPI } from '../../../utils/client'
 import { fetchFitnessActivities } from '..'
 
 describe('Fetch Fitness Activities', () => {
   beforeEach(() => {
-    moxios.install(instance)
+    moxios.install(servicesAPI)
   })
 
   afterEach(() => {
-    moxios.uninstall(instance)
+    moxios.uninstall(servicesAPI)
   })
 
   it('throws with incorrect params', () => {
@@ -15,33 +15,25 @@ describe('Fetch Fitness Activities', () => {
     expect(test).to.throw
   })
 
-  it('fetches activities for a campaign', done => {
-    fetchFitnessActivities({ campaign: '12345678' })
+  it('throws with fetching activities for a campaign', () => {
+    const test = () => fetchFitnessActivities({ campaign: '12345678' })
+    expect(test).to.throw
+  })
 
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('/v1/fitness/campaign')
-      expect(request.url).to.contain('campaignGuid=12345678')
-      done()
-    })
+  it('throws with fetching activities for a team', () => {
+    const test = () => fetchFitnessActivities({ team: 'test-team' })
+    expect(test).to.throw
   })
 
   it('fetches activities for a page', done => {
-    fetchFitnessActivities({ page: 'test-page', useLegacy: true })
+    fetchFitnessActivities({ page: 'test-page' })
 
     moxios.wait(() => {
       const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('/v1/fitness/fundraising/test-page')
-      done()
-    })
-  })
-
-  it('fetches activities for a team', done => {
-    fetchFitnessActivities({ team: 'test-team' })
-
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('/v1/fitness/teams/test-team')
+      console.log(request)
+      expect(request.url).to.contain(
+        'https://api.blackbaud.services/v1/justgiving/graphql'
+      )
       done()
     })
   })

--- a/source/api/fitness-activities/index.js
+++ b/source/api/fitness-activities/index.js
@@ -120,8 +120,8 @@ export const fetchFitnessActivities = (params = required()) => {
 
   if (params.page) {
     if (params.useLegacy) {
-      return get(`/v1/fitness/fundraising/${params.page}`, query).then(
-        response => response.activities
+      return Promise.reject(
+        'Legacy method no longer supported since it does not return individual activities'
       )
     }
 

--- a/source/api/fitness-activities/index.js
+++ b/source/api/fitness-activities/index.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import lodashGet from 'lodash/get'
-import { get, post, destroy, servicesAPI } from '../../utils/client'
-import { paramsSerializer, required } from '../../utils/params'
+import { post, destroy, servicesAPI } from '../../utils/client'
+import { required } from '../../utils/params'
 import { convertToMeters, convertToSeconds } from '../../utils/units'
 import { extractData } from '../../utils/graphql'
 import { encodeBase64String } from '../../utils/base64'
@@ -111,13 +111,6 @@ export const deserializeFitnessActivity = (activity = required()) => {
 }
 
 export const fetchFitnessActivities = (params = required()) => {
-  const query = {
-    limit: params.limit || 100,
-    offset: params.offset || 0,
-    start: params.startDate,
-    end: params.endDate
-  }
-
   if (params.page) {
     if (params.useLegacy) {
       return Promise.reject(
@@ -183,18 +176,15 @@ export const fetchFitnessActivities = (params = required()) => {
   }
 
   if (params.team) {
-    return get(`/v1/fitness/teams/${params.team}`, query).then(
-      response => response.activities
+    return Promise.reject(
+      "Fetching list of a team's individual activities is not supported"
     )
   }
 
   if (params.campaign) {
-    return get(
-      '/v1/fitness/campaign',
-      { ...query, campaignGuid: params.campaign },
-      {},
-      { paramsSerializer }
-    ).then(response => response.activities)
+    return Promise.reject(
+      "Fetching list of a campaign's individual activities is not supported"
+    )
   }
 
   return required()


### PR DESCRIPTION
The old v1 fitness endpoints no longer return fitness activities (just an empty array now) so we can't really use the legacy prop anymore here.