### PR TITLE
Map address data to updated field names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -212,7 +212,16 @@ class CreatePageForm extends Component {
   }
 
   handleAddressLookup (address) {
-    this.props.form.updateValues(address)
+    const addressFields = {
+      streetAddress: address.streetAddress,
+      extendedAddress: address.extendedAddress,
+      localityAddress: address.locality,
+      regionAddress: address.region,
+      postCodeAddress: address.postCode,
+      countryAddress: address.country
+    }
+
+    this.props.form.updateValues(addressFields)
     this.setState({ manualAddress: true })
   }
 


### PR DESCRIPTION
**Problem**

After selecting an address, it would use `form.updateValues` to add the selected address data to the form values. However, it was adding them using the old field names (e.g. region, country), rather than the updated field names (e.g. regionAddress, countryAddress). That caused weird issues where the CreatePageForm would not update the region/country etc, and would actually render new fields as part of it's auto-rendering of fields.

**Solution**

Map the address data to the new field names.

**Before**

![image](https://user-images.githubusercontent.com/1445686/131754625-4592b33c-68eb-45d9-b6d7-9629fac1b35b.png)

**After**

![image](https://user-images.githubusercontent.com/1445686/131754633-f30cf226-6588-4296-814e-08f7a9c36a04.png)
