### PR TITLE
Show invalid styles for address search input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/address-search/index.js
+++ b/source/components/address-search/index.js
@@ -55,7 +55,7 @@ class AddressSearch extends Component {
   }
 
   render () {
-    const { error, inputProps, validations } = this.props
+    const { error, inputProps, touched, validations } = this.props
     const { country, results, status, value } = this.state
 
     return (
@@ -77,6 +77,7 @@ class AddressSearch extends Component {
           <InputSearch
             autoComplete='nope'
             error={error}
+            invalid={!!error}
             label={this.renderLabel()}
             onChange={this.handleSelect}
             onSearch={this.handleQuery}
@@ -84,6 +85,7 @@ class AddressSearch extends Component {
             showMore
             status={status}
             placeholder='Search postcode'
+            touched={touched}
             validations={validations}
             value={value}
             {...inputProps}

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -304,6 +304,7 @@ class CreatePageForm extends Component {
           inputProps={inputField}
           label={addressSearchLabel}
           required
+          touched={form.fields.streetAddress.touched}
           validations={form.fields.streetAddress.validations}
           {...addressSearchProps}
         />


### PR DESCRIPTION
Previously there was no red border around address search input despite showing a validation error message

<img width="611" alt="Screen Shot 2021-09-03 at 4 33 06 pm" src="https://user-images.githubusercontent.com/729085/131960901-81a001fe-70ba-4356-8c5b-69b43e2f3d90.png">
