### PR TITLE
QR codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -7,7 +7,7 @@ import lodashFilter from 'lodash/filter'
 import slugify from 'slugify'
 import { v4 as uuid } from 'uuid'
 import { get, post, put, servicesAPI } from '../../utils/client'
-import { apiImageUrl, baseUrl, imageUrl } from '../../utils/justgiving'
+import { apiUrl, apiImageUrl, baseUrl, imageUrl } from '../../utils/justgiving'
 import { getUID, isEqual, isEmpty, isUuid, required } from '../../utils/params'
 import { defaultPageTags } from '../../utils/tags'
 import { deserializeFitnessActivity } from '../fitness-activities'
@@ -65,6 +65,7 @@ export const deserializePage = page => {
     donationUrl: id
       ? `${baseUrl('link')}/v1/fundraisingpage/donate/pageId/${id}`
       : `${baseUrl('www')}/fundraising/${shortName}/donate`,
+    donateQrCodeImage: `${apiUrl()}/v1/fundraising/pages/${shortName}/qrcode`,
     event: page.Subtext || page.eventId || page.EventId || page.eventName,
     expired: jsonDate(page.expiryDate) && dayjs(page.expiryDate).isBefore(),
     fitness: page.fitness || {},

--- a/source/api/qrcodes/__tests__/qrcode-test.js
+++ b/source/api/qrcodes/__tests__/qrcode-test.js
@@ -1,0 +1,32 @@
+import { createQrCode } from '..'
+import { instance } from '../../../utils/client'
+
+describe('Create QR Code', () => {
+  beforeEach(() => {
+    moxios.install(instance)
+  })
+
+  afterEach(() => {
+    moxios.uninstall(instance)
+  })
+
+  it('uses the correct url', done => {
+    createQrCode(
+      'https://link.justgiving.com/v1/fundraisingpage/donate/pageId/1234'
+    )
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.include(
+        'https://api.justgiving.com/v1/qrcodes/create'
+      )
+      expect(request.url).to.include('1234')
+      done()
+    })
+  })
+
+  it('throws if no url is provided', () => {
+    const test = () => createQrCode()
+    expect(test).to.throw
+  })
+})

--- a/source/api/qrcodes/index.js
+++ b/source/api/qrcodes/index.js
@@ -1,0 +1,9 @@
+import { get } from '../../utils/client'
+import { required } from '../../utils/params'
+
+export const createQrCode = (
+  linkUrl = required(),
+  logoUrl = 'https://images.justgiving.com/image/f468c25c-93e5-4e2d-bcb9-eb525559fb43.jpg'
+) => {
+  return get('/v1/qrcodes/create', { linkUrl, logoUrl })
+}

--- a/source/utils/client/index.js
+++ b/source/utils/client/index.js
@@ -49,6 +49,8 @@ export const updateClient = (options = {}) => {
 
 export const getBaseURL = () => instance.defaults.baseURL
 
+export const getApiKey = () => instance.defaults.headers['x-api-key']
+
 export const isStaging = () => /staging/.test(instance.defaults.baseURL)
 
 // Services API Client

--- a/source/utils/justgiving/index.js
+++ b/source/utils/justgiving/index.js
@@ -1,4 +1,4 @@
-import { isStaging, servicesAPI } from '../client'
+import { getApiKey, isStaging, servicesAPI } from '../client'
 import get from 'lodash/get'
 
 export const isValidJSON = json => {
@@ -36,6 +36,8 @@ const parseTextSection = (section = {}) => {
 export const baseUrl = (subdomain = 'www') => {
   return `https://${subdomain}${isStaging() ? '.staging' : ''}.justgiving.com`
 }
+
+export const apiUrl = () => `${baseUrl('api')}/${getApiKey()}`
 
 export const imageUrl = (image, template = 'CrowdfundingOwnerAvatar') => {
   return image


### PR DESCRIPTION
I started off adding support for the generic 'create QR code' method, which could be useful in future. It allows you to generate a QR code with any valid justgiving.com URL and an uploaded image to JG image service, e.g. 

```
createQrCode(
  'https://www.justgiving.com/campaign/yorkshireappeal/donate',
  'https://images.justgiving.com/image/4f10bd59-1a97-47b2-9d4a-8369a49cd71f.png'
)
```

generates the following QR code image:

![Example with custom image](https://images.justgiving.com/image/391ebb11-dfa4-4264-8ebd-71319d291fb5.jpg)

However, then I found there's a method that does some of the magic behind the scenes and just gives you back an image, so I added that to the `deserializePage` method.

_FYI the default image used in `createQrCode` is the same image used to create QR codes via the method used in `deserializePage`._