### PR TITLE
Use Bearer auth by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/source/api/authentication/__tests__/sign-in--test.js
+++ b/source/api/authentication/__tests__/sign-in--test.js
@@ -14,6 +14,7 @@ describe('Authentication | Sign In', () => {
 
   it('should hit the JG api with the correct url and data', done => {
     signIn({
+      authType: 'Basic',
       email: 'test@gmail.com',
       password: 'password'
     })

--- a/source/api/authentication/__tests__/sign-up--test.js
+++ b/source/api/authentication/__tests__/sign-up--test.js
@@ -33,7 +33,7 @@ describe('Authentication | Sign Up', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         const data = JSON.parse(request.config.data)
-        expect(request.url).to.eql('/v1/account')
+        expect(request.url).to.eql('/v1/justgiving/iam/register')
         expect(data.email).to.eql('test@gmail.com')
         done()
       })
@@ -41,6 +41,7 @@ describe('Authentication | Sign Up', () => {
 
     it('without address supplied', done => {
       signUp({
+        authType: 'Basic',
         firstName: 'Just',
         lastName: 'Giving',
         email: 'test@gmail.com',
@@ -70,9 +71,7 @@ describe('Authentication | Sign Up', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         const data = JSON.parse(request.config.data)
-        expect(request.url).to.eql(
-          '/v1/justgiving/iam/register'
-        )
+        expect(request.url).to.eql('/v1/justgiving/iam/register')
         expect(data.email).to.eql('test@gmail.com')
         done()
       })
@@ -89,7 +88,7 @@ describe('Authentication | Sign Up', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         const data = JSON.parse(request.config.data)
-        expect(request.url).to.eql('/v1/account/lite')
+        expect(request.url).to.eql('/v1/justgiving/iam/register')
         expect(data.email).to.eql('test@gmail.com')
         done()
       })

--- a/source/api/authentication/index.js
+++ b/source/api/authentication/index.js
@@ -31,7 +31,7 @@ export const validateToken = (token = required()) =>
 export const signIn = ({
   email = required(),
   password = required(),
-  authType = 'Basic'
+  authType = 'Bearer'
 }) => {
   if (authType === 'Basic') {
     const token = encodeBase64String(`${email}:${password}`)
@@ -70,7 +70,7 @@ export const signUp = ({
   cause,
   phone,
   reference,
-  authType = 'Basic'
+  authType = 'Bearer'
 }) => {
   if (authType === 'Basic') {
     const payload = {

--- a/source/api/me/__tests__/fetch-user--test.js
+++ b/source/api/me/__tests__/fetch-user--test.js
@@ -22,7 +22,7 @@ describe('Fetch User', () => {
       const request = moxios.requests.mostRecent()
       expect(request.url).to.contain('/v1/account')
       expect(request.config.headers['Authorization']).to.eql(
-        'Basic dGVzdEBleGFtcGxlLmNvbTpmb29iYXIxMjM='
+        'Bearer dGVzdEBleGFtcGxlLmNvbTpmb29iYXIxMjM='
       )
       done()
     })

--- a/source/api/me/index.js
+++ b/source/api/me/index.js
@@ -63,7 +63,7 @@ export const deserializeUser = user => ({
 
 export const fetchCurrentUser = ({
   token = required(),
-  authType = 'Basic'
+  authType = 'Bearer'
 }) => {
   if (authType === 'Basic' || token.length > 32) {
     return get(
@@ -91,7 +91,7 @@ export const updateCurrentUser = ({
   token = required(),
   uuid = required(),
   email = required(),
-  authType = 'Basic',
+  authType = 'Bearer',
   firstName,
   lastName,
   address = {}

--- a/source/api/metadata/index.js
+++ b/source/api/metadata/index.js
@@ -15,7 +15,7 @@ export const fetchMetadata = ({
   app = required(),
   token = required(),
   id,
-  authType = 'Basic'
+  authType = 'Bearer'
 }) =>
   metadataAPI
     .get(`/v1/apps/${app}/metadata`, {
@@ -29,7 +29,7 @@ export const createMetadata = ({
   token = required(),
   id = required(),
   metadata = required(),
-  authType = 'Basic'
+  authType = 'Bearer'
 }) => {
   const headers = { Authorization: [authType, token].join(' ') }
   const values = keys(metadata).map(key => ({ key, value: metadata[key] }))
@@ -45,7 +45,7 @@ export const updateMetadata = ({
   id = required(),
   key = required(),
   value = required(),
-  authType = 'Basic'
+  authType = 'Bearer'
 }) =>
   metadataAPI
     .put(

--- a/source/api/pages/__tests__/create-page-test.js
+++ b/source/api/pages/__tests__/create-page-test.js
@@ -37,7 +37,7 @@ describe('Create Page', () => {
           '/v1/fundraising/pages'
         )
         expect(request.config.headers['Authorization']).to.eql(
-          'Basic 012345abcdef'
+          'Bearer 012345abcdef'
         )
         expect(JSON.parse(request.config.data).pageShortName).to.eql(
           'super-supporter-2'

--- a/source/api/pages/__tests__/update-page-test.js
+++ b/source/api/pages/__tests__/update-page-test.js
@@ -23,7 +23,7 @@ describe('Page | Update Page', () => {
       )
       expect(request.url).to.contain('fundraising-page')
       expect(request.config.headers['Authorization']).to.eql(
-        'Basic 012345abcdef'
+        'Bearer 012345abcdef'
       )
       done()
     })
@@ -42,7 +42,7 @@ describe('Page | Update Page', () => {
       )
       expect(request.url).to.contain('fundraising-page')
       expect(request.config.headers['Authorization']).to.eql(
-        'Basic 012345abcdef'
+        'Bearer 012345abcdef'
       )
       done()
     })

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -189,7 +189,7 @@ const recursivelyFetchJGPages = ({
 export const fetchPages = (params = required()) => {
   const {
     allPages,
-    authType = 'Basic',
+    authType = 'Bearer',
     campaign,
     charity,
     event,
@@ -288,7 +288,7 @@ export const fetchPage = (page = required(), slug, options = {}) => {
 }
 
 export const fetchUserPages = ({
-  authType = 'Basic',
+  authType = 'Bearer',
   campaign,
   charity,
   event,
@@ -417,7 +417,7 @@ export const createPage = ({
   slug,
   activityType = 'othercelebration',
   attribution,
-  authType = 'Basic',
+  authType = 'Bearer',
   campaignId,
   campaignGuid,
   causeId,
@@ -528,7 +528,7 @@ export const updatePage = (
   {
     token = required(),
     attribution,
-    authType = 'Basic',
+    authType = 'Bearer',
     image,
     name,
     offline,

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -457,7 +457,7 @@ CreatePageForm.propTypes = {
 }
 
 CreatePageForm.defaultProps = {
-  authType: 'Basic',
+  authType: 'Bearer',
   charityFunded: false,
   disableInvalidForm: false,
   fields: {},

--- a/source/components/single-sign-on-link/index.js
+++ b/source/components/single-sign-on-link/index.js
@@ -129,7 +129,7 @@ SingleSignOnLink.propTypes = {
 }
 
 SingleSignOnLink.defaultProps = {
-  authType: 'Basic',
+  authType: 'Bearer',
   label: 'My Fundraising Page',
   target: '_top',
   method: 'POST'

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,8 +1,8 @@
 const path = require('path')
 const camelCase = require('lodash/camelCase')
 const upperFirst = require('lodash/upperFirst')
-const { version } = require('./package.json')
 const { styles, theme } = require('./styleguide.styles')
+const { version } = require('./package.json')
 
 module.exports = {
   title: `Supporticon ${version}`,


### PR DESCRIPTION
We really only use `Basic` auth these days for interacting with the Data API.