### PR TITLE
remove numbro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:unit": "mocha source/**/**/__tests__/*.js --require @babel/register --require test/common.js",
     "test": "npm run test:lint && npm run test:unit",
     "format": "prettier-standard 'source/**/*.js'",
-    "precommit": "lint-staged",
+    "precommit": "yarn lint-staged",
     "docsify:watch": "docsify serve ./source",
     "styleguide:build": "styleguidist build",
     "docs:build": "npm run styleguide:build && gulp docs-prepare",
@@ -72,7 +72,6 @@
   },
   "peerDependencies": {
     "constructicon": "^3.0.0 || ^4.0.0",
-    "numbro": "^1.0.0 || ^2.0.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },
@@ -95,11 +94,9 @@
     ]
   },
   "lint-staged": {
-    "linters": {
-      "source/**/*.js": [
-        "prettier-standard",
-        "git add"
-      ]
-    }
+    "source/**/*.js": [
+      "prettier-standard",
+      "git add"
+    ]
   }
 }

--- a/source/api/donations/index.js
+++ b/source/api/donations/index.js
@@ -1,4 +1,4 @@
-import numbro from 'numbro'
+import { formatNumber } from '../../utils/numbers'
 import jsonDate from '../../utils/jsonDate'
 import { stringify } from 'querystringify'
 import { get } from '../../utils/client'
@@ -32,7 +32,7 @@ export const buildDonationUrl = ({
   ...args
 }) => {
   const params = stringify({
-    amount: numbro(amount).format('0.00'),
+    amount: formatNumber({ amount }),
     currency,
     ...args
   })

--- a/source/components/donation-ticker/README.md
+++ b/source/components/donation-ticker/README.md
@@ -14,7 +14,6 @@
 ```
 <DonationTicker
   campaign='e5e9b4eb-b97c-415d-b324-004708c0bd38'
-  format='0a'
   layout='amount-only'
   ticker={{
     background: 'secondary',

--- a/source/components/donation-ticker/index.js
+++ b/source/components/donation-ticker/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
+import { formatCurrency } from '../../utils/numbers'
 import { fetchDonationFeed, deserializeDonation } from '../../api/feeds'
 
 import Loading from 'constructicon/loading'
@@ -74,8 +74,11 @@ class DonationTicker extends Component {
   }
 
   formatDonation (donation) {
-    const { layout, format } = this.props
-    const formattedAmount = numbro(donation.amount).formatCurrency(format)
+    const { layout } = this.props
+    const formattedAmount = formatCurrency({
+      amount: donation.amount,
+      currencyCode: donation.currency
+    })
 
     switch (layout) {
       case 'name-only':
@@ -118,17 +121,13 @@ class DonationTicker extends Component {
     const { label, ticker } = this.props
     const { donations, status } = this.state
 
-    return status === 'fetched'
-      ? (
-        <Ticker label={label} items={donations} {...ticker} />
-        )
-      : status === 'failed'
-        ? (
-          <Metric icon='warning' label='An error occurred' />
-          )
-        : (
-          <Loading />
-          )
+    if (status === 'fetched') {
+      return <Ticker label={label} items={donations} {...ticker} />
+    }
+    if (status === 'failed') {
+      return <Metric icon='warning' label='An error occurred' />
+    }
+    return <Loading />
   }
 }
 
@@ -184,11 +183,6 @@ DonationTicker.propTypes = {
   ]),
 
   /**
-   * Donation amount format
-   */
-  format: PropTypes.string,
-
-  /**
    * Recursively fetch all donations (up to 5000)
    */
   fetchAll: PropTypes.bool,
@@ -235,7 +229,6 @@ DonationTicker.propTypes = {
 
 DonationTicker.defaultProps = {
   fetchAll: false,
-  format: '0,0[.]00',
   layout: 'name-amount',
   ticker: {}
 }

--- a/source/components/fitness-leaderboard/README.md
+++ b/source/components/fitness-leaderboard/README.md
@@ -5,6 +5,7 @@
 ```
 <FitnessLeaderboard
   campaign='31fde560-dc11-43ca-9696-e373818208a3'
+  places={2}
 />
 ```
 
@@ -16,6 +17,7 @@
   limit={100}
   pageSize={10}
   showPage
+  unit={false}
   leaderboard={{
     columns: {
       sm: 2
@@ -86,6 +88,7 @@
   offset={-50000}
   page={1}
   pageSize={5}
+  places={3}
   units={false}
 />
 ```

--- a/source/components/fitness-progress-bar/README.md
+++ b/source/components/fitness-progress-bar/README.md
@@ -4,6 +4,7 @@
 <FitnessProgressBar
   campaign='96e2266e-2fa2-4109-a2b6-c017b79011bd'
   target={500000}
+  places={3}
 />
 ```
 

--- a/source/components/fitness-progress-bar/index.js
+++ b/source/components/fitness-progress-bar/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import dayjs from 'dayjs'
-import numbro from 'numbro'
+import { formatNumber } from '../../utils/numbers'
 import { fetchFitnessTotals } from '../../api/fitness-totals'
 
 import Grid from 'constructicon/grid'
@@ -64,10 +64,10 @@ class FitnessProgressBar extends Component {
       distanceLabel,
       eventDate,
       grid,
-      format,
       heading,
       metric,
       offset,
+      places,
       progressBar,
       remainingLabel,
       target,
@@ -80,14 +80,17 @@ class FitnessProgressBar extends Component {
     const distanceInKm = distanceInMeters / 1000
     const distance = unit === 'km' ? distanceInKm : distanceInKm * 0.621371
 
-    return status === 'fetched'
-      ? (
+    if (status === 'fetched') {
+      return (
         <Grid spacing={0.25} {...grid}>
           <GridColumn xs={6}>
             <Metric
               align='left'
               label={distanceLabel}
-              amount={`${numbro(distance + offset).format(format)}${unit}`}
+              amount={`${formatNumber({
+                amount: distance + offset,
+                places
+              })}${unit}`}
               {...metric}
             />
           </GridColumn>
@@ -95,7 +98,7 @@ class FitnessProgressBar extends Component {
             <Metric
               align='right'
               label={targetLabel}
-              amount={`${numbro(target).format(format)}${unit}`}
+              amount={`${formatNumber({ amount: target, places })}${unit}`}
               {...metric}
             />
           </GridColumn>
@@ -106,32 +109,28 @@ class FitnessProgressBar extends Component {
               {...progressBar}
             />
           </GridColumn>
-          {travelledLabel
-            ? (
-              <GridColumn xs={6}>
+          <GridColumn xs={6}>
+            {travelledLabel && (
+              <>
                 <Heading size={0} tag='strong' {...heading}>
                   {this.calculatePercentage()}%
                 </Heading>{' '}
                 {travelledLabel}
-              </GridColumn>
-              )
-            : (
-              <GridColumn xs={6} />
-              )}
-          {remainingLabel &&
-            eventDate && (
-              <GridColumn xs={6} xsAlign='right'>
-                <Heading size={0} tag='strong' {...heading}>
-                  {this.calculateDaysRemaining(eventDate)}
-                </Heading>{' '}
-                {remainingLabel}
-              </GridColumn>
+              </>
+            )}
+          </GridColumn>
+          {remainingLabel && eventDate && (
+            <GridColumn xs={6} xsAlign='right'>
+              <Heading size={0} tag='strong' {...heading}>
+                {this.calculateDaysRemaining(eventDate)}
+              </Heading>{' '}
+              {remainingLabel}
+            </GridColumn>
           )}
         </Grid>
-        )
-      : (
-        <Loading />
-        )
+      )
+    }
+    return <Loading />
   }
 }
 
@@ -187,6 +186,11 @@ FitnessProgressBar.propTypes = {
   heading: PropTypes.object,
 
   /**
+   * The max number of places after decimal point to display
+   */
+  places: PropTypes.number,
+
+  /**
    * Props to be passed to the Constructicon Metric components
    */
   metric: PropTypes.object,
@@ -213,7 +217,7 @@ FitnessProgressBar.propTypes = {
 }
 
 FitnessProgressBar.defaultProps = {
-  format: '0,0',
+  places: '0',
   unit: 'km',
   offset: 0
 }

--- a/source/components/leaderboard/README.md
+++ b/source/components/leaderboard/README.md
@@ -4,6 +4,15 @@
 ```
 <Leaderboard
   campaign='e5e9b4eb-b97c-415d-b324-004708c0bd38'
+  country='us'
+/>
+```
+
+*Set Country*
+```
+<Leaderboard
+  campaign='e5e9b4eb-b97c-415d-b324-004708c0bd38'
+  country='us'
 />
 ```
 

--- a/source/components/progress-bar/README.md
+++ b/source/components/progress-bar/README.md
@@ -3,7 +3,7 @@
 ```
 <ProgressBar
   campaign='31fde560-dc11-43ca-9696-e373818208a3'
-  target={200000}
+  target={2000000}
 />
 ```
 
@@ -13,7 +13,7 @@
   useDonationCount
   raisedLabel='Donations'
   targetLabel='Target'
-  target={1000}
+  target={100000}
 />
 ```
 
@@ -22,8 +22,8 @@
   campaign='31fde560-dc11-43ca-9696-e373818208a3'
   raisedLabel='Raised'
   targetLabel='Target'
-  target={200000}
-  offset={15000}
+  target={2000000}
+  offset={350000}
   eventDate='2018-09-09'
   fundedLabel='funded'
   remainingLabel='days remaining'

--- a/source/components/progress-bar/index.js
+++ b/source/components/progress-bar/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import dayjs from 'dayjs'
-import numbro from 'numbro'
+import { formatCurrency, formatNumber } from '../../utils/numbers'
 import {
   fetchDonationTotals,
   deserializeDonationTotals
@@ -77,7 +77,6 @@ class ProgressBar extends Component {
   render () {
     const {
       eventDate,
-      format,
       fundedLabel,
       grid,
       heading,
@@ -92,9 +91,8 @@ class ProgressBar extends Component {
     } = this.props
 
     const { raised, donations, status } = this.state
-
-    return status === 'fetched'
-      ? (
+    if (status === 'fetched') {
+      return (
         <Grid spacing={0.25} {...grid}>
           <GridColumn xs={6}>
             <Metric
@@ -102,8 +100,8 @@ class ProgressBar extends Component {
               label={raisedLabel}
               amount={
                 useDonationCount
-                  ? numbro(donations + offset).format(format)
-                  : numbro(raised + offset).formatCurrency(format)
+                  ? formatNumber({ amount: donations + offset })
+                  : formatCurrency({ amount: raised + offset })
               }
               {...metric}
             />
@@ -114,8 +112,8 @@ class ProgressBar extends Component {
               label={targetLabel}
               amount={
                 useDonationCount
-                  ? numbro(target).format(format)
-                  : numbro(target).formatCurrency(format)
+                  ? formatNumber({ amount: target })
+                  : formatCurrency({ amount: target })
               }
               {...metric}
             />
@@ -127,32 +125,28 @@ class ProgressBar extends Component {
               {...progressBar}
             />
           </GridColumn>
-          {fundedLabel
-            ? (
-              <GridColumn xs={6}>
+          <GridColumn xs={6}>
+            {fundedLabel && (
+              <>
                 <Heading size={0} tag='strong' {...heading}>
                   {this.calculatePercentage()}%
                 </Heading>{' '}
                 {fundedLabel}
-              </GridColumn>
-              )
-            : (
-              <GridColumn xs={6} />
-              )}
-          {remainingLabel &&
-            eventDate && (
-              <GridColumn xs={6} xsAlign='right'>
-                <Heading size={0} tag='strong' {...heading}>
-                  {this.calculateDaysRemaining(eventDate)}
-                </Heading>{' '}
-                {remainingLabel}
-              </GridColumn>
+              </>
+            )}
+          </GridColumn>
+          {remainingLabel && eventDate && (
+            <GridColumn xs={6} xsAlign='right'>
+              <Heading size={0} tag='strong' {...heading}>
+                {this.calculateDaysRemaining(eventDate)}
+              </Heading>{' '}
+              {remainingLabel}
+            </GridColumn>
           )}
         </Grid>
-        )
-      : (
-        <Loading />
-        )
+      )
+    }
+    return <Loading />
   }
 }
 
@@ -251,11 +245,6 @@ ProgressBar.propTypes = {
   remainingLabel: PropTypes.string,
 
   /**
-   * The format of the number
-   */
-  format: PropTypes.string,
-
-  /**
    * Props to be passed to the Constructicon Grid component
    */
   grid: PropTypes.object,
@@ -288,7 +277,6 @@ ProgressBar.propTypes = {
 
 ProgressBar.defaultProps = {
   excludeOffline: false,
-  format: '0,0',
   offset: 0
 }
 

--- a/source/components/team-leaderboard/index.js
+++ b/source/components/team-leaderboard/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
 import orderBy from 'lodash/orderBy'
 import { deserializeTeamPage, fetchTeamPages } from '../../api/teams'
 import {
@@ -9,6 +8,7 @@ import {
   formatDuration,
   formatElevation
 } from '../../utils/fitness'
+import { formatCurrency, formatNumber } from '../../utils/numbers'
 
 import Grid from 'constructicon/grid'
 import LeaderboardItem from 'constructicon/leaderboard-item'
@@ -59,17 +59,17 @@ const TeamLeaderboard = ({
         case 'activities':
           return formatActivities(amount)
         case 'distance':
-          return formatDistance(amount, miles, format)
+          return formatDistance({ amount, miles, label: format })
         case 'duration':
           return formatDuration(amount, format)
         case 'elevation':
           return formatElevation(amount, miles, format)
         default:
-          return numbro(amount).formatCurrency('0,0')
+          return formatCurrency({ amount })
       }
     }
 
-    return numbro(amount).format('0,0')
+    return formatNumber({ amount })
   }
 
   const fetchData = () =>
@@ -122,23 +122,22 @@ const TeamLeaderboard = ({
               />
             ))}
           </Leaderboard>
-          {pageSize &&
-            isPaginated && (
-              <Section spacing={{ t: 0.5 }}>
-                <Grid align='center' justify='center'>
-                  <PaginationLink
-                    onClick={prev}
-                    direction='prev'
-                    disabled={!canPrev}
-                  />
-                  {showPage && <RichText size={-1}>{pageOf}</RichText>}
-                  <PaginationLink
-                    onClick={next}
-                    direction='next'
-                    disabled={!canNext}
-                  />
-                </Grid>
-              </Section>
+          {pageSize && isPaginated && (
+            <Section spacing={{ t: 0.5 }}>
+              <Grid align='center' justify='center'>
+                <PaginationLink
+                  onClick={prev}
+                  direction='prev'
+                  disabled={!canPrev}
+                />
+                {showPage && <RichText size={-1}>{pageOf}</RichText>}
+                <PaginationLink
+                  onClick={next}
+                  direction='next'
+                  disabled={!canNext}
+                />
+              </Grid>
+            </Section>
           )}
         </>
       )}
@@ -226,6 +225,7 @@ TeamLeaderboard.propTypes = {
 
 TeamLeaderboard.defaultProps = {
   activeOnly: true,
+  country: 'gb',
   limit: 250,
   multiplier: 1,
   offset: 0,

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
 import { fetchFitnessTotals } from '../../api/fitness-totals'
 import { formatDistance } from '../../utils/fitness'
+import { formatCurrency } from '../../utils/numbers'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -60,7 +60,7 @@ class TotalDistance extends Component {
 
   renderAmount () {
     const { status, data } = this.state
-    const { format, miles, multiplier, offset, units } = this.props
+    const { miles, multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -70,14 +70,14 @@ class TotalDistance extends Component {
         return <Icon name='warning' />
       default:
         return units
-          ? formatDistance(amount, miles)
-          : numbro(amount).format(format)
+          ? formatDistance({ amount, miles, places })
+          : formatCurrency({ amount })
     }
   }
 
   renderAmountLabel () {
     const { status, data } = this.state
-    const { format, miles, multiplier, offset, units } = this.props
+    const { miles, multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -87,8 +87,8 @@ class TotalDistance extends Component {
         return 'Error'
       default:
         return units
-          ? formatDistance(amount, miles, 'full')
-          : numbro(amount).format(format)
+          ? formatDistance({ amount, miles, label: 'full', places })
+          : formatCurrency({ amount })
     }
   }
 }
@@ -121,9 +121,9 @@ TotalDistance.propTypes = {
   label: PropTypes.string,
 
   /**
-   * The format of the number
+   * The max number of places after decimal point to display
    */
-  format: PropTypes.string,
+  places: PropTypes.number,
 
   /**
    * Use imperial units (miles, feet, yards)
@@ -169,11 +169,11 @@ TotalDistance.propTypes = {
 }
 
 TotalDistance.defaultProps = {
-  format: '0,0',
   label: 'Total Distance',
   miles: false,
   multiplier: 1,
   offset: 0,
+  places: 0,
   units: true
 }
 

--- a/source/components/total-donations/README.md
+++ b/source/components/total-donations/README.md
@@ -11,5 +11,6 @@
 ```
 <TotalDonations
   event='4872958'
+  places={2}
 />
 ```

--- a/source/components/total-donations/index.js
+++ b/source/components/total-donations/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
+import { formatNumber } from '../../utils/numbers'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -81,7 +81,7 @@ class TotalDonations extends Component {
   renderAmount () {
     const { status, data = {} } = this.state
 
-    const { format, offset, multiplier } = this.props
+    const { offset, multiplier } = this.props
 
     switch (status) {
       case 'fetching':
@@ -89,7 +89,7 @@ class TotalDonations extends Component {
       case 'failed':
         return <Icon name='warning' />
       default:
-        return numbro((offset + data.donations) * multiplier).format(format)
+        return formatNumber({ amount: (offset + data.donations) * multiplier })
     }
   }
 }
@@ -169,11 +169,6 @@ TotalDonations.propTypes = {
   multiplier: PropTypes.number,
 
   /**
-   * The format of the number
-   */
-  format: PropTypes.string,
-
-  /**
    * The label of the metric
    */
   label: PropTypes.string,
@@ -203,7 +198,6 @@ TotalDonations.propTypes = {
 
 TotalDonations.defaultProps = {
   excludeOffline: false,
-  format: '0,0',
   label: 'Donations',
   multiplier: 1,
   offset: 0

--- a/source/components/total-duration/README.md
+++ b/source/components/total-duration/README.md
@@ -20,6 +20,7 @@
 <TotalDuration
   campaign='31fde560-dc11-43ca-9696-e373818208a3'
   multiplier={0.5}
+  places={2}
   offset={1}
   units={false}
 />

--- a/source/components/total-duration/index.js
+++ b/source/components/total-duration/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
 import { fetchFitnessTotals } from '../../api/fitness-totals'
 import { formatDuration } from '../../utils/fitness'
+import { formatNumber } from '../../utils/numbers'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -60,7 +60,7 @@ class TotalDuration extends Component {
 
   renderAmount () {
     const { status, data } = this.state
-    const { format, multiplier, offset, units } = this.props
+    const { multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -69,13 +69,13 @@ class TotalDuration extends Component {
       case 'failed':
         return <Icon name='warning' />
       default:
-        return units ? formatDuration(amount) : numbro(amount).format(format)
+        return units ? formatDuration(amount) : formatNumber({ amount, places })
     }
   }
 
   renderAmountLabel () {
     const { status, data } = this.state
-    const { format, multiplier, offset, units } = this.props
+    const { multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -86,7 +86,7 @@ class TotalDuration extends Component {
       default:
         return units
           ? formatDuration(amount, 'full')
-          : numbro(amount).format(format)
+          : formatNumber({ amount, places })
     }
   }
 }
@@ -114,9 +114,12 @@ TotalDuration.propTypes = {
   multiplier: PropTypes.number,
 
   /**
-   * The format of the number
+   * The max number of places after decimal point to display
    */
-  format: PropTypes.string,
+  /**
+   * The max number of places after decimal point to display
+   */
+  places: PropTypes.number,
 
   /**
    * The label of the metric
@@ -162,9 +165,9 @@ TotalDuration.propTypes = {
 }
 
 TotalDuration.defaultProps = {
-  format: '0,0',
   label: 'Total Duration',
   multiplier: 1,
+  places: 0,
   offset: 0,
   units: true
 }

--- a/source/components/total-elevation/README.md
+++ b/source/components/total-elevation/README.md
@@ -22,6 +22,7 @@
   campaign='e5e9b4eb-b97c-415d-b324-004708c0bd38'
   multiplier={0.5}
   offset={1}
+  places={2}
   units={false}
 />
 ```

--- a/source/components/total-elevation/index.js
+++ b/source/components/total-elevation/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
 import { fetchFitnessTotals } from '../../api/fitness-totals'
 import { formatElevation } from '../../utils/fitness'
+import { formatNumber } from '../../utils/numbers'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -54,7 +54,7 @@ class TotalElevation extends Component {
 
   renderAmount () {
     const { status, data } = this.state
-    const { format, miles, multiplier, offset, units } = this.props
+    const { miles, multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -65,13 +65,13 @@ class TotalElevation extends Component {
       default:
         return units
           ? formatElevation(amount, miles)
-          : numbro(amount).format(format)
+          : formatNumber({ amount, places })
     }
   }
 
   renderAmountLabel () {
     const { status, data } = this.state
-    const { format, miles, multiplier, offset, units } = this.props
+    const { miles, multiplier, offset, places, units } = this.props
     const amount = (offset + data) * multiplier
 
     switch (status) {
@@ -82,7 +82,7 @@ class TotalElevation extends Component {
       default:
         return units
           ? formatElevation(amount, miles, 'full')
-          : numbro(amount).format(format)
+          : formatNumber({ amount, places })
     }
   }
 }
@@ -110,9 +110,9 @@ TotalElevation.propTypes = {
   multiplier: PropTypes.number,
 
   /**
-   * The format of the number
+   * The max number of places after decimal point to display
    */
-  format: PropTypes.string,
+  places: PropTypes.number,
 
   /**
    * The label of the metric
@@ -163,11 +163,11 @@ TotalElevation.propTypes = {
 }
 
 TotalElevation.defaultProps = {
-  format: '0,0',
   label: 'Total Elevation',
   miles: false,
   multiplier: 1,
   offset: 0,
+  places: 0,
   units: true
 }
 

--- a/source/components/total-funds-raised/README.md
+++ b/source/components/total-funds-raised/README.md
@@ -12,5 +12,7 @@ Exclude offline donations from total:
 <TotalFundsRaised
   campaign='31fde560-dc11-43ca-9696-e373818208a3'
   excludeOffline
+  places={2}
+  currency={false}
 />
 ```

--- a/source/components/total-funds-raised/index.js
+++ b/source/components/total-funds-raised/index.js
@@ -1,16 +1,14 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
-
-import Icon from 'constructicon/icon'
-import Loading from 'constructicon/loading'
-import Metric from 'constructicon/metric'
-
 import {
   fetchDonationTotals,
   deserializeDonationTotals
 } from '../../api/donation-totals'
+import { formatCurrency, formatNumber } from '../../utils/numbers'
 
+import Icon from 'constructicon/icon'
+import Loading from 'constructicon/loading'
+import Metric from 'constructicon/metric'
 class TotalFundsRaised extends Component {
   constructor () {
     super()
@@ -80,16 +78,17 @@ class TotalFundsRaised extends Component {
 
   renderAmount () {
     const { status, data = {} } = this.state
-    const { currency, format, offset, multiplier } = this.props
-    const formatMethod = currency ? 'formatCurrency' : 'format'
-
+    const { currency, offset, multiplier, places } = this.props
+    const amount = (offset + data.raised) * multiplier
     switch (status) {
       case 'fetching':
         return <Loading />
       case 'failed':
         return <Icon name='warning' />
       default:
-        return numbro((offset + data.raised) * multiplier)[formatMethod](format)
+        return currency
+          ? formatCurrency({ amount })
+          : formatNumber({ amount, places })
     }
   }
 }
@@ -179,9 +178,9 @@ TotalFundsRaised.propTypes = {
   label: PropTypes.string,
 
   /**
-   * The format of the number
+   * The max number of places after decimal point to display
    */
-  format: PropTypes.string,
+  places: PropTypes.number,
 
   /**
    * The icon to use
@@ -209,10 +208,10 @@ TotalFundsRaised.propTypes = {
 TotalFundsRaised.defaultProps = {
   currency: true,
   excludeOffline: false,
-  format: '0,0',
   label: 'Funds Raised',
   multiplier: 1,
-  offset: 0
+  offset: 0,
+  places: 0
 }
 
 export default TotalFundsRaised

--- a/source/components/total-supporters/index.js
+++ b/source/components/total-supporters/index.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import numbro from 'numbro'
+import { formatNumber } from '../../utils/numbers'
 import { fetchPagesTotals } from '../../api/pages-totals'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
 import Metric from 'constructicon/metric'
-
 class TotalSupporters extends Component {
   constructor () {
     super()
@@ -77,7 +76,7 @@ class TotalSupporters extends Component {
   renderAmount () {
     const { status, data = {} } = this.state
 
-    const { format, offset, multiplier } = this.props
+    const { offset, multiplier, places } = this.props
 
     switch (status) {
       case 'fetching':
@@ -85,7 +84,7 @@ class TotalSupporters extends Component {
       case 'failed':
         return <Icon name='warning' />
       default:
-        return numbro((offset + data) * multiplier).format(format)
+        return formatNumber({ amount: (offset + data) * multiplier, places })
     }
   }
 }
@@ -156,9 +155,9 @@ TotalSupporters.propTypes = {
   multiplier: PropTypes.number,
 
   /**
-   * The format of the number
+   * The max number of places after decimal point to display
    */
-  format: PropTypes.string,
+  places: PropTypes.number,
 
   /**
    * The label of the metric
@@ -192,7 +191,7 @@ TotalSupporters.defaultProps = {
   label: 'Supporters',
   offset: 0,
   multiplier: 1,
-  format: '0,0',
+  places: 0,
   type: 'individual'
 }
 

--- a/source/utils/fitness/index.js
+++ b/source/utils/fitness/index.js
@@ -1,8 +1,8 @@
-import numbro from 'numbro'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import get from 'lodash/get'
 import * as units from '../units'
+import { formatNumber } from '../numbers'
 
 dayjs.extend(duration)
 
@@ -28,15 +28,20 @@ export const formatMeasurementDomain = sortBy => {
   }
 }
 
-export const formatDistance = (distance, miles, label = 'abbreviation') => {
+export const formatDistance = ({
+  amount,
+  miles,
+  label = 'abbreviation',
+  places = 0
+}) => {
   if (miles) {
     return (
-      numbro(units.convertMetersToMiles(distance)).format('0,0[.]0[0]') +
+      formatNumber({ amount: units.convertMetersToMiles(amount), places }) +
       ` ${labels.miles[label]}`
     )
   } else {
     return (
-      numbro(units.convertMetersToKm(distance)).format('0,0[.]0[0]') +
+      formatNumber({ amount: units.convertMetersToKm(amount), places }) +
       ` ${labels.kilometers[label]}`
     )
   }
@@ -58,19 +63,26 @@ export const formatDuration = (duration, label = 'abbreviation') => {
   }
 }
 
-export const formatElevation = (elevation, miles, label = 'abbreviation') => {
+export const formatElevation = (
+  elevation,
+  miles,
+  label = 'abbreviation',
+  places
+) => {
   if (miles) {
     return (
-      numbro(units.convertMetersToFeet(elevation)).format('0,0') +
+      formatNumber({ amount: units.convertMetersToFeet(elevation), places }) +
       ` ${labels.feet[label]}`
     )
   } else {
-    return numbro(elevation).format('0,0') + ` ${labels.meters[label]}`
+    return (
+      formatNumber({ amount: elevation, places }) + ` ${labels.meters[label]}`
+    )
   }
 }
 
-export const formatActivities = activities => {
-  return numbro(activities).format('0,0')
+export const formatActivities = (activities, places) => {
+  return formatNumber({ amount: activities, places })
 }
 
 export const getDistanceTotal = (page = {}) => {

--- a/source/utils/numbers/index.js
+++ b/source/utils/numbers/index.js
@@ -1,0 +1,72 @@
+const setLocaleFromCurrency = currencyCode => {
+  const code = currencyCode.toLowerCase()
+  switch (code) {
+    case 'aud':
+      return 'en-AU'
+    case 'ca':
+      return 'en-CA'
+    case 'hk':
+      return 'en-HK'
+    case 'ie':
+    case 'eur':
+      return 'en-IE'
+    case 'nzd':
+      return 'en-NZ'
+    case 'sgd':
+      return 'en-SG'
+    case 'usd':
+      return 'en-US'
+    case 'zar':
+      return 'en-ZA'
+    default:
+      return 'en-GB'
+  }
+}
+
+export const setLocaleFromCountry = country => `en-${country.toUpperCase()}`
+
+export const setCurrencyFromCountry = location => {
+  const country = location.toLowerCase()
+  switch (country) {
+    case 'au':
+      return 'aud'
+    case 'ca':
+      return 'CAD'
+    case 'hk':
+      return 'HKD'
+    case 'ie':
+      return 'EUR'
+    case 'nz':
+      return 'NZD'
+    case 'sg':
+      return 'SGD'
+    case 'us':
+      return 'usd'
+    case 'za':
+      return 'zar'
+    default:
+      return 'gbp'
+  }
+}
+
+export const formatNumber = ({ amount, places = 0, locale }) => {
+  const country = !locale ? setLocaleFromCountry('gb') : locale
+  return new Intl.NumberFormat(country, {
+    maximumFractionDigits: amount > 999999 ? Math.max(1, places) : places,
+    notation: amount > 999999 ? 'compact' : 'standard'
+  }).format(amount)
+}
+
+export const formatCurrency = ({ amount, currencyCode = 'gbp', locale }) => {
+  const country = !locale ? setLocaleFromCurrency(currencyCode) : locale
+  const isLargeNumber = amount > 999999
+  const isWholeNumber = amount % 1 === 0
+
+  return new Intl.NumberFormat(country, {
+    style: 'currency',
+    currency: currencyCode.toUpperCase(),
+    minimumFractionDigits: isWholeNumber || isLargeNumber ? 0 : 2,
+    maximumFractionDigits: isLargeNumber ? 1 : 2,
+    notation: isLargeNumber ? 'compact' : 'standard'
+  }).format(amount)
+}


### PR DESCRIPTION
- replace numbro with native web api number and currency formatting. As a result, removing format prop, which was used to hook into numbro API. Instead, replacing with a places prop to allow floating decimals (defaults to 0).
- remove advanced config in lint-staged (otherwise was not letting me commit)
- also, new version of standard not liking some of the ternary conditionals (especially in JSX) so some updates there to get around lint errors