### PR TITLE
fix leaderboard to pass query from filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/index.js
+++ b/source/api/leaderboard/index.js
@@ -26,7 +26,7 @@ export const fetchLeaderboard = (params = required()) => {
     }).then(results => removeExcludedPages(results, params.excludePageIds))
   }
 
-  if (!isEmpty(params.campaign) && params.allPages) {
+  if (!isEmpty(params.campaign) && (params.allPages || params.q)) {
     return recursivelyFetchJGLeaderboard(
       getUID(params.campaign),
       params.q,


### PR DESCRIPTION
There is a bug with leaderboard components where the filter is not actually submitting a search. This is because we need to add conditional for when a 'q' prop is present to make sure to use the campaign page search endpoint.

Quick video:
https://watch.screencastify.com/v/BZKcQQfT7vsfyFDNSoVC