### PR TITLE
Remove tag leaderboard results with zero values

### DIFF
--- a/source/api/leaderboard/index.js
+++ b/source/api/leaderboard/index.js
@@ -37,7 +37,11 @@ export const fetchLeaderboard = (params = required()) => {
         ? params.campaign.map(getUID).join(',')
         : getUID(params.campaign),
       type: 'campaign'
-    }).then(results => removeExcludedPages(results, params.excludePageIds))
+    })
+      .then(results => removeExcludedPages(results, params.excludePageIds))
+      .then(results =>
+        results.filter(item => lodashGet(item, 'amounts[0].value', 0) > 0)
+      )
   }
 
   if (params.campaign && params.useGraphql) {


### PR DESCRIPTION
If a page has a given value (raised or fitness total) and then a tag value is changed after the fact, it will have its aggregations updated to the 'correct' leaderboard. That said, the node still remains in the old leaderboard with a zero value. This change removes it from appearing on the 'wrong' leaderboard.