### PR TITLE
Update fetch posts & fitness activities methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "10.0.3",
+  "version": "10.1.0",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/source/api/posts/index.js
+++ b/source/api/posts/index.js
@@ -10,6 +10,7 @@ export const deserializePost = post => ({
   id: post.id,
   createdAt: post.createdAt,
   message: post.message,
+  legacyId: post.legacyId,
   media: post.media,
   image: getMedia(
     post,
@@ -25,13 +26,12 @@ export const fetchPosts = ({
   slug = required(),
   allPosts = false,
   after,
-  results = [],
-  type = 'FUNDRAISING'
+  results = []
 }) => {
   const query = `
-    {
-      page(type: ${type}, slug: "${slug}") {
-        timeline(first: 20${after ? `, after: "${after}"` : ''}) {
+    query getPosts($slug: Slug, $after: String) {
+      page(type: FUNDRAISING, slug: $slug) {
+        timeline(first: 20, entryType: MANUAL, after: $after) {
           pageInfo {
             hasNextPage
             endCursor
@@ -55,7 +55,7 @@ export const fetchPosts = ({
   `
 
   return servicesAPI
-    .post('/v1/justgiving/graphql', { query })
+    .post('/v1/justgiving/graphql', { query, variables: { slug, after } })
     .then(response => response.data)
     .then(result => {
       const data = lodashGet(result, 'data.page.timeline', {})


### PR DESCRIPTION
Turns out there's an `entryType` param available in the `timeline` connection in FRP graphQL requests, which filters by the type requested.

This means we'll only fetch a page's posts OR fitness activities when making the related request, not all and then filter out the other type.

I've also made sure that the timeline entry's `legacyId` field is available in the deserialised response, as it's easier to work with than the base64 encoded `id`.