### PR TITLE
Use correct API base URL based on env var

### DIFF
--- a/source/utils/client/index.js
+++ b/source/utils/client/index.js
@@ -55,7 +55,9 @@ export const isStaging = () => /staging/.test(instance.defaults.baseURL)
 
 // Services API Client
 export const servicesAPI = axios.create({
-  baseURL: 'https://api.blackbaud.services'
+  baseURL: isStaging()
+    ? 'https://api-staging.blackbaud.services'
+    : 'https://api.blackbaud.services'
 })
 
 const updateServicesAPIClient = () => {
@@ -66,7 +68,9 @@ const updateServicesAPIClient = () => {
 
 // Metadata API Client
 export const metadataAPI = axios.create({
-  baseURL: 'https://metadata.blackbaud.services'
+  baseURL: isStaging()
+    ? 'https://metadata-staging.blackbaud.services'
+    : 'https://metadata.blackbaud.services'
 })
 
 const updateMetadataAPIClient = () => {
@@ -77,7 +81,9 @@ const updateMetadataAPIClient = () => {
 
 // JG Images Client
 export const imagesAPI = axios.create({
-  baseURL: 'https://images.justgiving.com'
+  baseURL: isStaging()
+    ? 'https://images.staging.justgiving.com'
+    : 'https://images.justgiving.com'
 })
 
 const updateImagesAPIClient = () => {
@@ -88,7 +94,9 @@ const updateImagesAPIClient = () => {
 
 // JG Identity Client
 export const jgIdentityClient = axios.create({
-  baseURL: 'https://identity.justgiving.com'
+  baseURL: isStaging()
+    ? 'https://identity.staging.justgiving.com'
+    : 'https://identity.justgiving.com'
 })
 
 const updateJGIdentityClient = () => {


### PR DESCRIPTION
The `SUPPORTICON_BASE_URL` env var sets the default base URL for the JG API axios client used throughout.

The other clients however (services API, metadata, images and identity) were not being set based on this env var by default. This change means that if this env var is present, we don't need to call `updateClient` at all.