### PR TITLE
Add support for metrics/leaderboards filtered by campaign AND charity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "10.1.12",
+  "version": "10.2.0",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -83,6 +83,17 @@ describe('Donation Totals', () => {
         done()
       })
     })
+
+    it('uses the correct url to fetch totals for a charity within a campaign', done => {
+      fetchDonationTotals({ campaign: 1234, charity: 5678 })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.include(
+          '/donationsleaderboards/v1/totals?campaignGuids=1234&charityIds=5678'
+        )
+        done()
+      })
+    })
   })
 
   describe('Deserialize donation totals', () => {

--- a/source/api/donation-totals/index.js
+++ b/source/api/donation-totals/index.js
@@ -88,6 +88,7 @@ export const fetchDonationTotals = (params = required()) => {
       return client.get(
         '/donationsleaderboards/v1/totals',
         {
+          campaignGuids,
           charityIds: Array.isArray(params.charity)
             ? params.charity.map(getUID)
             : getUID(params.charity),

--- a/source/api/fitness-totals/index.js
+++ b/source/api/fitness-totals/index.js
@@ -1,5 +1,5 @@
 import * as client from '../../utils/client'
-import { paramsSerializer, required } from '../../utils/params'
+import { isEmpty, paramsSerializer, required } from '../../utils/params'
 import { fetchTotals, deserializeTotals } from '../../utils/totals'
 
 export const fetchFitnessSummary = (campaign = required(), types) =>
@@ -7,6 +7,7 @@ export const fetchFitnessSummary = (campaign = required(), types) =>
 
 export function fetchFitnessTotals ({
   campaign = required(),
+  charity,
   limit = 100,
   offset = 0,
   useLegacy = true,
@@ -15,6 +16,20 @@ export function fetchFitnessTotals ({
   tagId,
   tagValue
 }) {
+  if (!isEmpty(charity)) {
+    return fetchTotals({
+      segment: `page:campaign:${campaign}:charity:${charity}`,
+      tagId: 'page:campaign:charity',
+      tagValue: `page:campaign:${campaign}:charity:${charity}`
+    })
+      .then(deserializeTotals)
+      .then(result => ({
+        distance: result.fitnessDistanceTotal,
+        duration: result.fitnessDurationTotal,
+        elevation: result.fitnessElevationTotal
+      }))
+  }
+
   if ((tagId && tagValue) || !useLegacy) {
     return fetchTotals({
       segment: `page:campaign:${campaign}`,

--- a/source/api/leaderboard/index.js
+++ b/source/api/leaderboard/index.js
@@ -53,7 +53,7 @@ export const fetchLeaderboard = (params = required()) => {
   }
 
   return Promise.all([
-    !isEmpty(params.campaign)
+    (!isEmpty(params.campaign) && isEmpty(params.charity))
       ? fetchCampaignGraphqlLeaderboard(params)
       : Promise.resolve([]),
     fetchLegacyLeaderboard(params)

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -11,6 +11,7 @@ import Metric from 'constructicon/metric'
 const TotalDistance = ({
   activity,
   campaign,
+  charity,
   endDate,
   icon,
   label,
@@ -27,6 +28,7 @@ const TotalDistance = ({
 }) => {
   const { data, status } = useFitnessTotals({
     campaign,
+    charity,
     endDate,
     startDate,
     tagId,

--- a/source/components/total-duration/index.js
+++ b/source/components/total-duration/index.js
@@ -11,6 +11,7 @@ import Metric from 'constructicon/metric'
 const TotalDuration = ({
   activity,
   campaign,
+  charity,
   endDate,
   icon,
   label,
@@ -26,6 +27,7 @@ const TotalDuration = ({
 }) => {
   const { data, status } = useFitnessTotals({
     campaign,
+    charity,
     endDate,
     startDate,
     tagId,

--- a/source/components/total-elevation/index.js
+++ b/source/components/total-elevation/index.js
@@ -10,6 +10,7 @@ import Metric from 'constructicon/metric'
 
 const TotalElevation = ({
   campaign,
+  charity,
   endDate,
   icon,
   label,
@@ -26,6 +27,7 @@ const TotalElevation = ({
 }) => {
   const { data, status } = useFitnessTotals({
     campaign,
+    charity,
     endDate,
     startDate,
     tagId,

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -22,7 +22,7 @@ export const dataSource = ({ event, charity, campaign, donationRef }) => {
     }
 
     return 'event'
-  } else if (!isEmpty(charity) && isEmpty(campaign)) {
+  } else if (!isEmpty(charity)) {
     return 'charity'
   } else if (!isEmpty(campaign)) {
     return 'campaign'
@@ -48,7 +48,7 @@ export const paramsSerializer = params =>
     .map(key => {
       const value = params[key]
 
-      if (!value) return false
+      if (isEmpty(value)) return false
 
       if (Array.isArray(value)) {
         return value.map(val => [key, val].join('=')).join('&')

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -51,6 +51,8 @@ export const paramsSerializer = params =>
       if (isEmpty(value)) return false
 
       if (Array.isArray(value)) {
+        if (!value[0]) return false
+
         return value.map(val => [key, val].join('=')).join('&')
       }
 


### PR DESCRIPTION
This enables support for a breakdown of individual charity performance in an MCE site

![metrics](https://user-images.githubusercontent.com/729085/152294177-f9bea5dd-f382-44c6-8293-ce0cd785cd81.png)

![leaderboards](https://user-images.githubusercontent.com/729085/152294182-4967a9af-63aa-49c9-931b-4e7512c20db0.png)