### PR TITLE
Add option to filter charity search by specific country

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "10.2.6",
+  "version": "10.3.0",
   "description": "A libary to handle fetching data from JustGiving",
   "main": "index.js",
   "scripts": {

--- a/source/api/charities/index.js
+++ b/source/api/charities/index.js
@@ -25,6 +25,8 @@ export const searchCharities = (params = required()) => {
   } else {
     const finalParams = {
       ...params,
+      country: params.country === 'uk' ? 'gb' : params.country,
+      filterCountry: !!params.country,
       i: 'Charity'
     }
 


### PR DESCRIPTION
The `filterCountry` option is required to actually filter the results by country, otherwise the `country` param is ignored. Also it expects 'GB' for country code rather than 'UK' – the rest are fine.