### PR TITLE
Add separate aggregations for fundraising vs fitness to account for timeBox

### DIFF
--- a/source/utils/tags/index.js
+++ b/source/utils/tags/index.js
@@ -139,6 +139,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:charity:${page.charityId}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:charity:${page.charityId}:all`
         }
       ]
     },
@@ -157,6 +161,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:charity:${page.charityId}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:charity:${page.charityId}:all`
         }
       ]
     },
@@ -175,6 +183,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:event:${page.event}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:event:${page.event}:all`
         }
       ]
     },
@@ -193,6 +205,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:event:${page.event}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:event:${page.event}:all`
         }
       ]
     },
@@ -211,6 +227,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:event:${page.event}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:event:${page.event}:all`
         }
       ]
     },
@@ -229,6 +249,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:charity:${page.charityId}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:charity:${page.charityId}:all`
         }
       ]
     }
@@ -250,6 +274,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:campaign:${page.campaign}:all`
         }
       ]
     },
@@ -268,6 +296,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:campaign:${page.campaign}:all`
         }
       ]
     },
@@ -286,6 +318,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}:charity:${page.charityId}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:campaign:${page.campaign}:charity:${page.charityId}:all`
         }
       ]
     },
@@ -304,6 +340,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:campaign:${page.campaign}:all`
         }
       ]
     },
@@ -322,6 +362,10 @@ export const defaultPageTags = (page, timeBox) => {
           measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}:charity:${page.charityId}`,
           timeBox
+        },
+        {
+          measurementDomains: ['all'],
+          segment: `page:campaign:${page.campaign}:charity:${page.charityId}:all`
         }
       ]
     }

--- a/source/utils/tags/index.js
+++ b/source/utils/tags/index.js
@@ -3,7 +3,12 @@ export const getPrimaryUnit = measurementDomain => {
     return 'count'
   }
 
-  if (['fundraising:donations_made', 'fundraising:offline_donations_count'].indexOf(measurementDomain) > -1) {
+  if (
+    [
+      'fundraising:donations_made',
+      'fundraising:offline_donations_count'
+    ].indexOf(measurementDomain) > -1
+  ) {
     return 'count'
   }
 
@@ -35,11 +40,14 @@ export const formatMeasurementDomain = sortBy => {
   }
 }
 
-export const measurementDomains = [
+export const fundraisingDomains = [
   'fundraising:donations_received',
   'fundraising:donations_made',
   'fundraising:offline_donations',
-  'fundraising:offline_donations_count',
+  'fundraising:offline_donations_count'
+]
+
+export const fitnessDomains = [
   'any:activities',
   'any:distance',
   'any:elapsed_time',
@@ -61,6 +69,8 @@ export const measurementDomains = [
   'walk:elapsed_time',
   'walk:elevation_gain'
 ]
+
+export const measurementDomains = [...fundraisingDomains, ...fitnessDomains]
 
 export const defaultPageTags = (page, timeBox) => {
   const tags = [
@@ -122,8 +132,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:charity:${page.charityId}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:charity:${page.charityId}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:charity:${page.charityId}`,
+          timeBox
         }
       ]
     },
@@ -135,7 +150,11 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:fundraising:${page.uuid}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
+          segment: `page:charity:${page.charityId}`
+        },
+        {
+          measurementDomains: fitnessDomains,
           segment: `page:charity:${page.charityId}`,
           timeBox
         }
@@ -149,8 +168,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:event:${page.event}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:event:${page.event}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:event:${page.event}`,
+          timeBox
         }
       ]
     },
@@ -162,7 +186,11 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:fundraising:${page.uuid}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
+          segment: `page:event:${page.event}`
+        },
+        {
+          measurementDomains: fitnessDomains,
           segment: `page:event:${page.event}`,
           timeBox
         }
@@ -176,8 +204,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: page.event,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:event:${page.event}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:event:${page.event}`,
+          timeBox
         }
       ]
     },
@@ -189,8 +222,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: page.charityId,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:charity:${page.charityId}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:charity:${page.charityId}`,
+          timeBox
         }
       ]
     }
@@ -205,8 +243,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: page.campaign,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:campaign:${page.campaign}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:campaign:${page.campaign}`,
+          timeBox
         }
       ]
     },
@@ -218,8 +261,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:campaign:${page.campaign}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:campaign:${page.campaign}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:campaign:${page.campaign}`,
+          timeBox
         }
       ]
     },
@@ -231,8 +279,13 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:campaign:${page.campaign}:charity:${page.charityId}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
           segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
+        },
+        {
+          measurementDomains: fitnessDomains,
+          segment: `page:campaign:${page.campaign}:charity:${page.charityId}`,
+          timeBox
         }
       ]
     },
@@ -244,7 +297,11 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:fundraising:${page.uuid}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
+          segment: `page:campaign:${page.campaign}`
+        },
+        {
+          measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}`,
           timeBox
         }
@@ -258,7 +315,11 @@ export const defaultPageTags = (page, timeBox) => {
       value: `page:fundraising:${page.uuid}`,
       aggregation: [
         {
-          measurementDomains: ['all'],
+          measurementDomains: fundraisingDomains,
+          segment: `page:campaign:${page.campaign}:charity:${page.charityId}`
+        },
+        {
+          measurementDomains: fitnessDomains,
           segment: `page:campaign:${page.campaign}:charity:${page.charityId}`,
           timeBox
         }


### PR DESCRIPTION
I decided to keep all the tags as the, rather than rocking the boat too much and requiring re-tagging lots of pages and having to make updates to the various fetching methods that depend on these tags.

Instead, for all the default tags, I apply 2 aggregations instead of 1. The first for the fundraising measurementDomains, which has no timeBox, and the second for the fitness measurementDomains, which applies the timeBox.

I re-tagged pages on Karl's campaign and it worked nicely. I also created a page and logged fitness in that same campaign which flowed through as expected.

Example GraphQL Leaderboard:

```
query {
  page (type: FUNDRAISING, slug: "dan-birmingham") {
    tags {
      tagDefinition {
        label
        id
      }
      value
      aggregation {
        measurementDomains
        segment
        timeBox {
          notBefore
          notAfter
        }
      }
    }
  }
}
```